### PR TITLE
Add option to not create a git repo

### DIFF
--- a/HaikuPorter/Options.py
+++ b/HaikuPorter/Options.py
@@ -86,9 +86,9 @@ def parseOptions():
 	parser.add_option('-e', '--extract-patchset',
 					  action='store_true', dest='extractPatchset', default=False,
 					  help='extract current patchset(s) from port source(s)')
-	parser.add_option('-G', '--init-git',
-					  action='store_true', dest='initGitRepo', default=False,
-					  help='create git-repo(s) for port source(s)')
+	parser.add_option('-G', '--no-git-repo',
+					  action='store_true', dest='noGitRepo', default=False,
+					  help="don't create git-repo(s) for port source(s)")
 	parser.add_option('-B', '--patch-files-only',
 					  action='store_true', dest='patchFilesOnly',
 					  default=False,

--- a/HaikuPorter/Source.py
+++ b/HaikuPorter/Source.py
@@ -262,6 +262,11 @@ class Source(object):
 
 		# use an implicit git repository for improved patch handling.
 		ensureCommandIsAvailable('git')
+		
+		# Check to see if there are any patches that need to be applied.
+		if not self.patches and getOption('noGitRepo'):
+			return False
+
 		if not self._isInGitWorkingDirectory(self.sourceDir):
 			# import sources into pristine git repository
 			self._initImplicitGitRepo()


### PR DESCRIPTION
This PR adds an option to ignore creating a git repo. This drastically reduces the time required to download & prepare packages.

It has a built in safety feature which will make the program create a repo if patches exist. This is used to prevent any issues with patches attempting to be applied when no git repo is available.