### PR TITLE
Fix error where --get doesn't work

### DIFF
--- a/HaikuPorter/Main.py
+++ b/HaikuPorter/Main.py
@@ -56,6 +56,11 @@ class Main(object):
 		self.treePath = Configuration.getTreePath()
 		self.outputDirectory = Configuration.getOutputDirectory()
 
+		# if requested, checkout or update ports tree
+		if self.options.get:
+			self._updatePortsTree()
+			return
+
 		self._checkFormatVersions()
 
 		# determine if haikuporter has just been invoked for a short-term
@@ -76,11 +81,6 @@ class Main(object):
 		self.packagesPath = self.outputDirectory + '/packages'
 		if not os.path.exists(self.packagesPath):
 			os.mkdir(self.packagesPath)
-
-		# if requested, checkout or update ports tree
-		if self.options.get:
-			self._updatePortsTree()
-			return
 
 		# if requested, print the location of the haikuports source tree
 		if self.options.tree:

--- a/HaikuPorter/Utils.py
+++ b/HaikuPorter/Utils.py
@@ -44,10 +44,10 @@ class MyTarInfo(tarfile.TarInfo):
 		return tarinfo
 
 # path to haikuports-tree --------------------------------------------------
-haikuportsRepoUrl = 'git@github.com:haikuports/haikuports.git'
+haikuportsRepoUrl = 'https://github.com/haikuports/haikuports.git'
 
 # path to haikuporter-tree
-haikuporterRepoUrl = 'git@github.com:haikuports/haikuporter.git'
+haikuporterRepoUrl = 'https://github.com/haikuports/haikuporter.git'
 
 def sysExit(message):
 	"""wrap invocation of sys.exit()"""


### PR DESCRIPTION
This closes #68.

Turns out the _checkFormatVersions() was being called before _updatePortsTree(), which would cause an issue if the haikuports repo was not installed. In addition, the URLs to the repos were not correct and threw errors.