### PR TITLE
Call tarfile.open with dereference=True to handle hard links.

### DIFF
--- a/HaikuPorter/SourceFetcher.py
+++ b/HaikuPorter/SourceFetcher.py
@@ -56,10 +56,10 @@ def unpackCheckoutWithTar(checkoutDir, sourceBaseDir, sourceSubDir, foldSubDir):
 	sourceDir = sourceBaseDir + '/' + sourceSubDir \
 		if sourceSubDir else sourceBaseDir
 	if foldSubDir:
-		command = ('tar -c -C "%s" --exclude-vcs | tar -x -C "%s"'
+		command = ('tar -c -C "%s" --exclude-vcs | tar -x --hard-dereference -C "%s"'
 				   % (foldSubDir, sourceDir))
 	else:
-		command = 'tar -c --exclude-vcs . | tar -x -C "%s"' % sourceDir
+		command = 'tar -c --exclude-vcs . | tar -x --hard-dereference -C "%s"' % sourceDir
 	check_call(command, cwd=checkoutDir, shell=True)
 
 	if foldSubDir:
@@ -270,10 +270,10 @@ class SourceFetcherForGit(object):
 		sourceDir = sourceBaseDir + '/' + sourceSubDir \
 			if sourceSubDir else sourceBaseDir
 		if foldSubDir:
-			command = ('git archive %s "%s" | tar -x -C "%s"'
+			command = ('git archive %s "%s" | tar -x --hard-dereference -C "%s"'
 					   % (self.rev, foldSubDir, sourceDir))
 		else:
-			command = 'git archive %s | tar -x -C "%s"' % (self.rev, sourceDir)
+			command = 'git archive %s | tar -x --hard-dereference -C "%s"' % (self.rev, sourceDir)
 		check_call(command, shell=True, cwd=self.fetchTarget)
 
 		if foldSubDir:

--- a/HaikuPorter/Utils.py
+++ b/HaikuPorter/Utils.py
@@ -86,7 +86,7 @@ def unpackArchive(archiveFile, targetBaseDir, subdir):
 		subdir += '/'
 	# unpack source archive
 	if tarfile.is_tarfile(archiveFile):
-		tarFile = tarfile.open(archiveFile, 'r', tarinfo=MyTarInfo)
+		tarFile = tarfile.open(archiveFile, 'r', dereference=True)
 		members = None
 		if subdir:
 			members = [
@@ -122,7 +122,7 @@ def unpackArchive(archiveFile, targetBaseDir, subdir):
 		Popen(['xz', '-f', '-d', '-k', archiveFile]).wait()
 		tar = archiveFile[:-3]
 		if tarfile.is_tarfile(tar):
-			tarFile = tarfile.open(tar, 'r', tarinfo=MyTarInfo)
+			tarFile = tarfile.open(tar, 'r', dereference=True)
 			members = None
 			if subdir:
 				if not subdir.endswith('/'):
@@ -142,7 +142,7 @@ def unpackArchive(archiveFile, targetBaseDir, subdir):
 		Popen(['lzip', '-f', '-d', '-k', archiveFile]).wait()
 		tar = archiveFile[:-3]
 		if tarfile.is_tarfile(tar):
-			tarFile = tarfile.open(tar, 'r', tarinfo=MyTarInfo)
+			tarFile = tarfile.open(tar, 'r', dereference=True)
 			members = None
 			if subdir:
 				if not subdir.endswith('/'):


### PR DESCRIPTION
* **`Utils.py`**: Use **`dereference=True`** (instead of **`tarinfo=MyTarInfo`**) when calling **`tarfile.open`** to handle archives with hard links.
* **`SourceFetcher.py`**: Use **`--hard-dereference`** when calling **`tar`**.