### PR TITLE
ShellScriptlets.py: fix corner-case bug in fixLibtoolArchives. (WIP)

### DIFF
--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -454,7 +454,7 @@ fixLibtoolArchives()
 	fi
 
 	for laFile in $installDestDir$developLibDir/*.la; do
-		for laPath in `sed 's/ /\n/g' < $laFile | sed '/\/packages.*\.la/p;/.*/d'`; do
+		for laPath in `sed "s/ /\n/g;s/'$//;" < $laFile | sed -n '/\/packages\/.*\.la/p;'`; do
 			lib="`echo "$laPath" | sed 's,.*/,,;s/\.la//'`"
 			for dep in "lib~$lib$secondaryArchSuffix" "lib~`echo "$lib" | tr '[A-Z]' '[a-z]'`$secondaryArchSuffix" "lib~${lib%%[0-9]*}$secondaryArchSuffix"; do
 				test -h "/packages/$portRevisionedName/$dep" && break
@@ -464,7 +464,7 @@ fixLibtoolArchives()
 				continue
 			fi
 			fixedLaPath="`echo "$laPath" | sed "s|/packages/[^/]*/[^/]*/|/packages/$portRevisionedName/$dep/|"`"
-			sed -i "s|$laPath|$fixedLaPath|g" "$laFile"
+			sed -i "s|${laPath%/*}\>|${fixedLaPath%/*}|g" "$laFile"
 		done
 	done
 }


### PR DESCRIPTION
* **`fixLibtoolArchives`** assumed each reference to an external **`lib*.la`** file was followed by a white space or by an end of line, but this is not true for the last **`lib*.la`** of the line because of the closing single quote. The basename of the libtool file was therefore not detected correctly, so the corresponding package-links directory could not be found for the last **`lib*.la`** of the **`dependency_libs`** parameter in the packages' libtool files. This is now fixed.
* Improve the substitution by using the dirnames of the libtool file instead of its full path. This allows to also fix any paths passed with -L.

_Reminder:_ The call to the **`fixLibtoolArchives`** helper function takes no arguments and should happen **before** the **`packageEntries devel ...`**