### PR TITLE
Include buildPlatform.targetArchitecture + '-' in workDir

### DIFF
--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -112,11 +112,17 @@ class Port(object):
 		self.filter = None
 
 		if secondaryArchitecture:
-			self.workDir = (outputDir + '/work-' + secondaryArchitecture
-							+ '-' + self.version)
+			self.workDir = (outputDir + '/work-'
+				+ self.version + '-'
+				+ buildPlatform.targetArchitecture + '-'
+				+ secondaryArchitecture
+			)
 			self.effectiveTargetArchitecture = self.secondaryArchitecture
 		else:
-			self.workDir = outputDir + '/work-' + self.version
+			self.workDir = (outputDir + '/work-'
+				+ self.version + '-'
+				+ buildPlatform.targetArchitecture
+			)
 			self.effectiveTargetArchitecture = buildPlatform.targetArchitecture
 
 		recipeCacheDir = os.path.join(self.repositoryDir, 'recipeCache')

--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -113,14 +113,14 @@ class Port(object):
 
 		if secondaryArchitecture:
 			self.workDir = (outputDir + '/work-'
-				+ self.version + '-'
+				+ self.version + '/'
 				+ buildPlatform.targetArchitecture + '-'
 				+ secondaryArchitecture
 			)
 			self.effectiveTargetArchitecture = self.secondaryArchitecture
 		else:
 			self.workDir = (outputDir + '/work-'
-				+ self.version + '-'
+				+ self.version + '/'
 				+ buildPlatform.targetArchitecture
 			)
 			self.effectiveTargetArchitecture = buildPlatform.targetArchitecture

--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -863,7 +863,7 @@ checkedUnmount()
 trap '' SIGINT
 
 # try to make sure we really are in a work directory
-if ! echo $(basename $PWD) | grep -qE '^work-'; then
+if ! echo $(basename `dirname "$PWD"`) | grep -qE '^work-'; then
 	echo "cleanupChroot invoked in $PWD, which doesn't seem to be a work dir!"
 	exit 1
 fi


### PR DESCRIPTION
so that each architecture has a unique work-* directory even if the haikuports tree is shared with multiple architectures.

Also put $portVersion right after 'work-' rather than at the end.
    
The new names for the work directories will be:
* "work-$portVersion-$targetArch" if building for a primary arch,
* "work-$portVersion-$targetArch-$secondaryArch" otherwise.

NOTICE: You can run: **`rm -rf /path/to/haikuporter/*/*/work-*`**

before or after you pull this commit, in order to get rid of the old work-\* directories. This is recommended, especially if you use x86_gcc2 hybrid or x86 hybrid or plan to do so.