### PR TITLE
Configuration: new optional REPOSITORY_PATH parameter

### DIFF
--- a/HaikuPorter/Configuration.py
+++ b/HaikuPorter/Configuration.py
@@ -251,6 +251,8 @@ class Configuration(object):
 			self.outputDirectory = self.treePath
 		if not self.packagesPath:
 			self.packagesPath = os.path.join(self.outputDirectory, 'packages')
+		if not self.repositoryDirectory:
+			self.repositoryDirectory = os.path.join(self.outputDirectory, 'repository')
 
 	@staticmethod
 	def init():

--- a/HaikuPorter/Configuration.py
+++ b/HaikuPorter/Configuration.py
@@ -138,13 +138,13 @@ haikuportsAttributes = {
 		'indexable': False,
 		'setAttribute': 'packager',
 	},
-	'REPOSITORY_DIRECTORY': {
+	'REPOSITORY_PATH': {
 		'type': types.StringType,
 		'required': False,
 		'default': None,
 		'extendable': Extendable.NO,
 		'indexable': False,
-		'setAttribute': 'repositoryDirectory',
+		'setAttribute': 'repositoryPath',
 	},
 	'SECONDARY_CROSS_DEVEL_PACKAGES': {
 		'type': types.ListType,
@@ -240,7 +240,7 @@ class Configuration(object):
 		self.crossDevelPackage = None
 		self.secondaryCrossDevelPackages = None
 		self.outputDirectory = None
-		self.repositoryDirectory = None
+		self.repositoryPath = None
 		self.vendor = None
 		self.packagesPath = None
 		self.sourceforgeMirror = None
@@ -251,8 +251,8 @@ class Configuration(object):
 			self.outputDirectory = self.treePath
 		if not self.packagesPath:
 			self.packagesPath = os.path.join(self.outputDirectory, 'packages')
-		if not self.repositoryDirectory:
-			self.repositoryDirectory = os.path.join(self.outputDirectory, 'repository')
+		if not self.repositoryPath:
+			self.repositoryPath = os.path.join(self.outputDirectory, 'repository')
 
 	@staticmethod
 	def init():
@@ -340,8 +340,8 @@ class Configuration(object):
 		return Configuration.configuration.outputDirectory
 
 	@staticmethod
-	def getRepositoryDirectory():
-		return Configuration.configuration.repositoryDirectory
+	def getRepositoryPath():
+		return Configuration.configuration.repositoryPath
 
 	@staticmethod
 	def getPackagesPath():

--- a/HaikuPorter/Configuration.py
+++ b/HaikuPorter/Configuration.py
@@ -138,6 +138,14 @@ haikuportsAttributes = {
 		'indexable': False,
 		'setAttribute': 'packager',
 	},
+	'REPOSITORY_DIRECTORY': {
+		'type': types.StringType,
+		'required': False,
+		'default': None,
+		'extendable': Extendable.NO,
+		'indexable': False,
+		'setAttribute': 'repositoryDirectory',
+	},
 	'SECONDARY_CROSS_DEVEL_PACKAGES': {
 		'type': types.ListType,
 		'required': False,
@@ -232,6 +240,7 @@ class Configuration(object):
 		self.crossDevelPackage = None
 		self.secondaryCrossDevelPackages = None
 		self.outputDirectory = None
+		self.repositoryDirectory = None
 		self.vendor = None
 		self.packagesPath = None
 		self.sourceforgeMirror = None
@@ -327,6 +336,10 @@ class Configuration(object):
 	@staticmethod
 	def getOutputDirectory():
 		return Configuration.configuration.outputDirectory
+
+	@staticmethod
+	def getRepositoryDirectory():
+		return Configuration.configuration.repositoryDirectory
 
 	@staticmethod
 	def getPackagesPath():

--- a/HaikuPorter/Main.py
+++ b/HaikuPorter/Main.py
@@ -59,7 +59,7 @@ class Main(object):
 		self.treePath = Configuration.getTreePath()
 		self.outputDirectory = Configuration.getOutputDirectory()
 		self.packagesPath = Configuration.getPackagesPath()
-		self.repositoryDirectory = Configuration.getRepositoryDirectory()
+		self.repositoryPath = Configuration.getRepositoryPath()
 
 		# create path where built packages will be collected
 		if not os.path.exists(self.packagesPath):
@@ -703,7 +703,7 @@ class Main(object):
 		if self.repository:
 			return
 		self.repository = Repository(self.treePath,
-			self.outputDirectory, self.repositoryDirectory,
+			self.outputDirectory, self.repositoryPath,
 			self.packagesPath, self.shellVariables, self.policy,
 			self.options.preserveFlags, quiet, verbose)
 

--- a/HaikuPorter/Main.py
+++ b/HaikuPorter/Main.py
@@ -59,6 +59,7 @@ class Main(object):
 		self.treePath = Configuration.getTreePath()
 		self.outputDirectory = Configuration.getOutputDirectory()
 		self.packagesPath = Configuration.getPackagesPath()
+		self.repositoryDirectory = Configuration.getRepositoryDirectory()
 
 		# create path where built packages will be collected
 		if not os.path.exists(self.packagesPath):
@@ -701,7 +702,8 @@ class Main(object):
 		"""create/update repository"""
 		if self.repository:
 			return
-		self.repository = Repository(self.treePath, self.outputDirectory,
+		self.repository = Repository(self.treePath,
+			self.outputDirectory, self.repositoryDirectory,
 			self.packagesPath, self.shellVariables, self.policy,
 			self.options.preserveFlags, quiet, verbose)
 

--- a/HaikuPorter/Repository.py
+++ b/HaikuPorter/Repository.py
@@ -28,12 +28,12 @@ class Repository(object):
 
 	currentFormatVersion = 1
 
-	def __init__(self, treePath, outputDirectory, repositoryDirectory,
+	def __init__(self, treePath, outputDirectory, repositoryPath,
 			packagesPath, shellVariables,
 			policy, preserveFlags, quiet = False, verbose = False):
 		self.treePath = treePath
 		self.outputDirectory = outputDirectory
-		self.path = repositoryDirectory
+		self.path = repositoryPath
 		self.inputSourcePackagesPath \
 			= self.outputDirectory + '/input-source-packages'
 		self.packagesPath = packagesPath

--- a/HaikuPorter/Repository.py
+++ b/HaikuPorter/Repository.py
@@ -28,11 +28,17 @@ class Repository(object):
 
 	currentFormatVersion = 1
 
-	def __init__(self, treePath, outputDirectory, packagesPath, shellVariables,
+	def __init__(self, treePath, outputDirectory, repositoryDirectory,
+			packagesPath, shellVariables,
 			policy, preserveFlags, quiet = False, verbose = False):
 		self.treePath = treePath
 		self.outputDirectory = outputDirectory
-		self.path = self.outputDirectory + '/repository-' + buildPlatform.targetArchitecture
+		if repositoryDirectory:
+			self.path = repositoryDirectory
+		else:
+			self.path = os.path.join(self.outputDirectory,
+				'repository-'
+				+ buildPlatform.targetArchitecture)
 		self.inputSourcePackagesPath \
 			= self.outputDirectory + '/input-source-packages'
 		self.packagesPath = packagesPath

--- a/HaikuPorter/Repository.py
+++ b/HaikuPorter/Repository.py
@@ -33,12 +33,7 @@ class Repository(object):
 			policy, preserveFlags, quiet = False, verbose = False):
 		self.treePath = treePath
 		self.outputDirectory = outputDirectory
-		if repositoryDirectory:
-			self.path = repositoryDirectory
-		else:
-			self.path = os.path.join(self.outputDirectory,
-				'repository-'
-				+ buildPlatform.targetArchitecture)
+		self.path = repositoryDirectory
 		self.inputSourcePackagesPath \
 			= self.outputDirectory + '/input-source-packages'
 		self.packagesPath = packagesPath


### PR DESCRIPTION
to allow relocation/specification of the repository directory.
~~Of course, this change is neutral if you don't set that parameter.~~

While at it, drop the suffix ('-' + $targetArchitecture) that was added to the default path for the repository directory, in the previous commit. The default path is therefore restored:
$OUTPUT_DIRECTORY/repository