### PR TITLE
Do not make the TEST phase depend on REQUIRES.

### DIFF
--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -1328,7 +1328,7 @@ class Port(object):
 		   environment (chroot) for the test stage"""
 
 		return self._getNeededPackages(packagesPath,
-			['REQUIRES', 'BUILD_REQUIRES', 'TEST_REQUIRES'],
+			['BUILD_REQUIRES', 'TEST_REQUIRES'],
 			'required packages for test', True)
 
 	def _executeBuild(self, makePackages):


### PR DESCRIPTION
Before the introduction of the `TEST_REQUIRES` variable, the `TEST` phase depended only on `BUILD_REQUIRES`. After `TEST_REQUIRES` was introduced, the `TEST` phase started to _also_ depend on `REQUIRES` and `TEST_REQUIRES`. The downside of making the `TEST` phase depend on `REQUIRES` is that, in some cases, haikuporter cannot satisfy such a dependency. That's because haikuporter considers the `REQUIRES` of the base package and _every_ subpackage. This means that if any subpackage has a dependency that cannot be met then `--test` becomes useless for that package.

The fix for this issue is easy:  make the `TEST` phase depend _only_ on `BUILD_REQUIRES` and `TEST_REQUIRES`.

This change does not break anything. It only means that, from now on, we will have to consider adding `TEST_REQUIRES="$REQUIRES"` if the `TEST` phase needs it. Hopefully, it seems we currently don't have any recipe that would need this.

Another advantage of this change is that the packages needed to run `haikuporter --test [--enter-chroot] <some-package>` will be restored to what that list was before the introduction of the `TEST_REQUIRES` variable, with the exception, of course, of what is mentioned in that variable.