### PR TITLE
Update requirements for packages of type any.

### DIFF
--- a/HaikuPorter/Package.py
+++ b/HaikuPorter/Package.py
@@ -225,8 +225,7 @@ class Package(object):
 	def makeHpkg(self, requiresUpdater):
 		"""Create a package suitable for distribution"""
 
-		if (requiresUpdater and self.type != PackageType.SOURCE
-			and self.architecture != Architectures.ANY):
+		if (requiresUpdater and self.type != PackageType.SOURCE):
 			requiresList = self.recipeKeys['REQUIRES']
 			self.recipeKeys['UPDATED_REQUIRES'] \
 				= requiresUpdater.updateRequiresList(requiresList)


### PR DESCRIPTION
This reverts 6eb039eb2da57667a5c2db993705933fea1182ef.

This is particularly annoying for perl and python packages which should be
depending on a version of perl or python.