### PR TITLE
DependencyResolver: remove whitespace before passing to pkgman

### DIFF
--- a/HaikuPorter/DependencyResolver.py
+++ b/HaikuPorter/DependencyResolver.py
@@ -237,7 +237,7 @@ class DependencyResolver(object):
 			if getOption('getDependencies'):
 				try:
 					print('Fetching package for ' + str(requires) + ' ...')
-					output = check_output(['pkgman', 'install', '-y', str(requires)])
+					output = check_output(['pkgman', 'install', '-y', str(requires).replace(' ', '')])
 					for pkg in re.findall(r'://.*/([^/\n]+\.hpkg)', output):
 						pkginfo = PackageInfo('/boot/system/packages/' + pkg)
 						self._providesManager.addProvidesFromPackageInfo(pkginfo)


### PR DESCRIPTION
pkgman doesn't seem to be able to process this: 'cmd:lrelease >= 5', but
it can if you remove all the spaces: 'cmd:lrelease>=5'.

Not sure if it's a pkgman bug.

Fixes #188