### PR TITLE
python3: errors from mutating collections while iterating

### DIFF
--- a/HaikuPorter/Repository.py
+++ b/HaikuPorter/Repository.py
@@ -298,7 +298,7 @@ class Repository(object):
 		# are supported, but we won't know until we have parsed the recipe file.
 		secondaryArchitectures = Configuration.getSecondaryTargetArchitectures()
 		if secondaryArchitectures:
-			for port in self._allPorts.values():
+			for port in tuple(self._allPorts.values()):
 				for architecture in secondaryArchitectures:
 					newPort = Port(port.baseName, port.version, port.category,
 						port.baseDir, port.outputDir, self.shellVariables,
@@ -546,11 +546,11 @@ class Repository(object):
 		"""drops any port-for-package mappings that refer to non-existing or
 		   broken ports"""
 
-		for packageId, portId in self._portIdForPackageId.items():
+		for packageId, portId in tuple(self._portIdForPackageId.items()):
 			if portId not in activePorts:
 				del self._portIdForPackageId[packageId]
 
-		for packageName, portName in self._portNameForPackageName.items():
+		for packageName, portName in tuple(self._portNameForPackageName.items()):
 			if portName not in self._portVersionsByName:
 				del self._portNameForPackageName[packageName]
 				continue


### PR DESCRIPTION
This function has two loops which iterate over the items in a dictionary and
then conditionally remove from that dictionary. dict.items() returns an
iterator and not a copy of the (key, value) pairs it contains, so it isn't
safe to remove from this loop.

This makes a copy of the items by converting the iterator to a tuple.

Fixes #199.