### PR TITLE
Policy: check if a package provides itself

### DIFF
--- a/HaikuPorter/Policy.py
+++ b/HaikuPorter/Policy.py
@@ -104,6 +104,11 @@ class Policy(object):
 		return names
 
 	def _checkProvides(self):
+		# check if the package provides itself
+		if self.package.name not in self.provides:
+			self._violation('no matching self provides for "%s"'
+				% self.package.name)
+
 		# everything in bin/ must be declared as cmd:*
 		binDir = os.path.join(self.package.packagingDir, 'bin')
 		if os.path.exists(binDir):


### PR DESCRIPTION
This is a common mistake, like when the package name is different than the provided command, it just happened to me again on hteditor.