### PR TITLE
python3: Use input instead of raw_input

### DIFF
--- a/HaikuPorter/Main.py
+++ b/HaikuPorter/Main.py
@@ -544,7 +544,7 @@ class Main(object):
 				return False
 
 			if not self.options.yes:
-				answer = raw_input('Continue (y/n + enter)? ')
+				answer = input('Continue (y/n + enter)? ')
 				if answer == '':
 					sys.exit(1)
 				if answer[0].lower() == 'y':


### PR DESCRIPTION
- Fixes https://github.com/haikuports/haikuporter/issues/215
- raw_input() has been deprecated and replaced with input()