### PR TITLE
BuildPlatform: assume 'which' command is available on Unix build host

### DIFF
--- a/HaikuPorter/BuildPlatform.py
+++ b/HaikuPorter/BuildPlatform.py
@@ -322,6 +322,7 @@ class BuildPlatformUnix(BuildPlatform):
 			'cmd:sed',
 			'cmd:strip',
 			'cmd:tar',
+			'cmd:which',
 			'cmd:xargs',
 			'cmd:xres',
 			'cmd:zcat',


### PR DESCRIPTION
Latest change in haikuporter introduces cmd:which as a prerequirement for shell scriptlets.
When I try to do bootstrap build, now I get the following error message:

`scriptlet-prerequires "cmd:which" of package "gcc_bootstrap-8.3.0_2019_05_24" could not be resolved`

This proposed change adds cmd:which to implicitBuildHostProvides when cross-building.