### PR TITLE
BuildPlatform: assume git is available on Unix build host

### DIFF
--- a/HaikuPorter/BuildPlatform.py
+++ b/HaikuPorter/BuildPlatform.py
@@ -305,6 +305,7 @@ class BuildPlatformUnix(BuildPlatform):
 			'cmd:find',
 			'cmd:flex',
 			'cmd:gcc',
+			'cmd:git',
 			'cmd:grep',
 			'cmd:gunzip',
 			'cmd:ld',


### PR DESCRIPTION
This seems to be needed to be able to bootstrap for arm.

Before: bootstrap fails with dependency issues
```
build-prerequires "cmd:git" of package "mesa_devel-21.3.7" could not be resolved
build-requires "devel:libgl" of package "libsdl2_devel-2.0.20" could not be resolved
build-requires "devel:libsdl2" of package "tk_devel-8.6.10" could not be resolved
build-requires "devel:libtk8.6" of package "python3-3.7.12" could not be resolved
build-prerequires "cmd:python3" of package "freetype-2.11.1" could not be resolved
build-requires "freetype" of package "meta_portsfile-1" could not be resolved

```

After: bootstrap is able to reach at least the stage when it's preparing the "rigged" source packages. (haven't finished yet, I hope that it will be successful)