### PR TITLE
ShellScriptlets: Escape single quotes in variables.

### DIFF
--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -49,7 +49,7 @@ def getShellVariableSetters(shellVariables):
 	if not shellVariables:
 		return ''
 
-	result = '\n'.join("%s='%s'" % (k, v)
+	result = '\n'.join("%s='%s'" % (k, v.replace("'", "'\\''"))
 		for k, v in shellVariables.items()) + '\n'
 
 	# Add a variable "revisionVariables" that contains the name of all


### PR DESCRIPTION
Variables containing single quotes cause problems when imported by Bash.
This patch fixes the issue by replacing `'` in these variables with `'\''`.

Fixes #145.