### PR TITLE
Introduce runCmake

### DIFF
--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -1213,18 +1213,23 @@ class Port(object):
 
 		# add one more variable containing all the dir args for CMake:
 		cmakeDirArgs = {
-			'PREFIX': prefix,
-			'SYSCONFDIR': portPackageLinksDir + '/.settings'
+			'CMAKE_INSTALL_PREFIX': prefix,
+			'CMAKE_INSTALL_SYSCONFDIR': portPackageLinksDir + '/.settings'
 			}
 		for k, v in relativeConfigureDirs.items():
-			cmakeDirArgs[k.upper()] = v
+			cmakeDirArgs['CMAKE_INSTALL_' + k.upper()] = v
 		self.shellVariables['cmakeDirArgs'] \
-			= ' '.join('-DCMAKE_INSTALL_%s=%s' % (k, v)
+			= ' '.join('-D%s=%s' % (k, v)
 				for k, v in cmakeDirArgs.items())
+
+		self.shellVariables.update(cmakeDirArgs)
 
 		# add another one with the list of possible variables
 		self.shellVariables['configureDirVariables'] \
 			= ' '.join(configureDirs.keys())
+
+		self.shellVariables['cmakeDirVariables'] \
+			= ' '.join(cmakeDirArgs.keys())
 
 		# Add variables for other standard directories. Consequently, we should
 		# use finddir to get them (also for the configure variables above), but

--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -319,6 +319,52 @@ runConfigure()
 	$configure $dirArgs $buildSpec $@
 }
 
+# helper function to invoke cmake with the correct directory
+# arguments
+runCmake()
+{
+	# parse arguments
+	varsToOmit=""
+
+	while [ $# -ge 1 ]; do
+		case $1 in
+			--omit-dirs)
+				shift 1
+				if [ $# -lt 1 ]; then
+					echo "runCmake: \"--omit-dirs\" needs an argument!" >&2
+				fi
+				varsToOmit="$1"
+				shift 1
+				;;
+			*)
+				break
+				;;
+		esac
+	done
+
+	if [ $# -lt 1 ]; then
+		echo "Usage: runCmake [ --omit-dirs <dirsToOmit> ]" \
+			"<argsToCmake> ..." >&2
+		echo "	<dirsToOmit>" >&2
+		echo "		Space-separated list of directory arguments not to be" >&2
+		echo "		passed to cmake, e.g. \"docDir manDir\" (single" >&2
+		echo "		argument!)." >&2
+		echo "	<argsToCmake>" >&2
+		echo "		The additional arguments passed to cmake." >&2
+		exit 1
+	fi
+
+	# build the directory arguments string
+	dirArgs=""
+	for dir in $cmakeDirVariables; do
+		if ! [[ "$varsToOmit" =~ (^|\ )${dir}($|\ ) ]]; then
+			dirArgs="$dirArgs -D${dir^^}=${!dir}"
+		fi
+	done
+
+	cmake $dirArgs $@
+}
+
 # helper function to validate CMake invocations (and use the correct one)
 cmake()
 {


### PR DESCRIPTION
Similarly to configure, sometimes we don't want to pass all the `CMAKE_INSTALL_xDIRS` to CMake. Adding `runCmake` that allows doing this using argument `--omit-dirs`

e.g. for wireshark:
```
runCmake --omit-dirs CMAKE_INSTALL_DATADIR \
    -S . -B build -G Ninja \
    -DCMAKE_EXE_LINKER_FLAGS="-lnetwork" \
    -DCMAKE_BUILD_TYPE=Release
```

This way I can build wireshark with correct dirs (it has its own non-standard default value for DATADIR what would have been overridden by `cmakeDirArgs`)