### PR TITLE
don't double-prepend Error: to messages

### DIFF
--- a/HaikuPorter/Utils.py
+++ b/HaikuPorter/Utils.py
@@ -62,7 +62,10 @@ haikuporterRepoUrl = 'https://github.com/haikuports/haikuporter.git'
 def sysExit(message):
 	"""wrap invocation of sys.exit()"""
 
-	message = '\n'.join([colorError + 'Error: ' + line + colorReset
+	prefix = colorError + 'Error: '
+	message = message.replace(prefix, '')  # in case we already had one, remove it before adding it again below
+
+	message = '\n'.join([prefix + line + colorReset
 		for line in message.split('\n')])
 	sys.exit(message)
 


### PR DESCRIPTION
before:

```
$ hp -b pkgdiff
Checking if any dependency-infos need to be updated ...
Looking for stale dependency-infos ...
Warning: skipping pkgdiff-1.7.2, as the recipe is broken
Error: Error: SUMMARY must start with a capital letter (/boot/home/haikuports/dev-util/pkgdiff/pkgdiff-1.7.2.recipe).
Error: No version of pkgdiff can be built
```

after:

```
$ hp -b pkgdiff
Checking if any dependency-infos need to be updated ...
Looking for stale dependency-infos ...
Warning: skipping pkgdiff-1.7.2, as the recipe is broken
Error: SUMMARY must start with a capital letter (/boot/home/haikuports/dev-util/pkgdiff/pkgdiff-1.7.2.recipe).
Error: No version of pkgdiff can be built
```