### PR TITLE
Revert "HaikuPorter ShellScriptlets: Validate there is only either a …

### DIFF
--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -428,15 +428,6 @@ prepareInstalledDevelLib()
 		fi
 	done
 
-	# Make sure there is not a static library in addition to a shared library.
-	if [ -f "$sharedLib" ] \
-			&& [ -f "$installDestDir$libDir/$libBaseName.a" \
-				-o -f "$installDestDir$developLibDir/$libBaseName.a" ]; then
-		echo "prepareInstalledDevelLib error:" \
-			"there is both a shared and a static library for $libBaseName!"
-		exit 1
-	fi
-
 	# Move things/create symlinks: The shared library file and the symlink for
 	# the soname remain where they are, but we create respective symlinks in the
 	# development directory. Everything else is moved there.


### PR DESCRIPTION
…shared or a static library."

* This is expected.  Packages can definitely ship static and shared libraries.
* Static libraries get placed into $developLibDir via prepareInstalledDevelLib for example:
  * libcurl.a gets moved to develop/libs
  * libcurl.so* gets left in libs
* gcc / ld chooses a static library via -static

This reverts commit 8a5746030dcf520390af89b46cd0a6aea6c72499.