### PR TITLE
ShellScriptlets: Fix meson setup command

### DIFF
--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -351,7 +351,11 @@ meson()
 		MESON=$(which meson)
 	fi
 
-	$MESON --wrap-mode=nodownload "$@"
+	if [[ "$1" == setup && "$*" != *wrap-mode* ]]; then
+		$MESON "$@" --wrap-mode=nodownload
+	else
+		$MESON "$@"
+	fi
 }
 
 fixDevelopLibDirReferences()


### PR DESCRIPTION
Put --wrap-mode=nodownload at the end of the arguments list, to avoid conflicting with the meson setup command. To allow recipes to override, only use it when wrap-mode isn't in the arguments. Fixes #249.