### PR TITLE
Support commented out lines in the PATCHES section.

### DIFF
--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -338,7 +338,9 @@ class Port(object):
 					# collect all referenced patches into a single list
 					if key in entries and entries[key]:
 						for index in entries[key].keys():
-							allPatches += entries[key][index]
+							allPatches += [
+								e for e in entries[key][index] if not e.strip(' \t').startswith('#')
+							]
 
 				# store extension-specific value under base key
 				recipeKeys[baseKey] = entries[key]

--- a/HaikuPorter/Source.py
+++ b/HaikuPorter/Source.py
@@ -63,7 +63,8 @@ class Source(object):
 		# make those absolute paths.
 		if self.patches and port.patchesDir:
 			self.patches = [
-				port.patchesDir + '/' + patch for patch in self.patches
+				port.patchesDir + '/'
+				+ patch for patch in self.patches if not patch.strip(' \t').startswith('#')
 			]
 
 		# ADDITIONAL_FILES refers to the files relative to the additional-files


### PR DESCRIPTION
We could have commented out lines in PROVIDES, and REQUIRES, but not in PATCHES, as those lines weren't being filtered out, ending on "file not found" errors further down.