### PR TITLE
Workaround for issue #207.

### DIFF
--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -1009,6 +1009,8 @@ if [[ $buildOk ]]; then
 		tmp \
 		var
 else
+	echo "cleaning 'chroot/boot' folder"
+	rm -rf boot
 	echo "keeping chroot folder $PWD intact for inspection"
 fi
 '''


### PR DESCRIPTION
Remove the boot dir from the chroot, even if $buildOK is false. This avoids that annoying "waiting for package to be activated".

Deleting just "boot/system/packages/administrative/activated_packages" might be enough, but... this works well for me, and it's already how it's done if $buildOK is true.