### PR TITLE
[FIX] Fix problems caused by changing script file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ HaikuPorts installation can be done via the following command sequence:
 ```
 
 ### Build port
- - `./haikuporter mesa -j4`
+ - `./haikuporter.py mesa -j4`
 
 ### Build port and all outdated dependency ports
- - `./haikuporter mesa --all-dependencies -j4`
+ - `./haikuporter.py mesa --all-dependencies -j4`
 
 ## Multi-node cluster (Linux + Haiku)
 

--- a/buildmaster/backend/README.md
+++ b/buildmaster/backend/README.md
@@ -47,6 +47,6 @@ One buildmaster container per architecture
 * haikuporter buildmaster then moves obsolete packages from /var/buildmaster/haikuports/packages /var/buildmaster/haikuports/packages/.obsolete/ (keeping in mind packages is a symlink)
   * This follows the basic haikuporter behaviour
 * haikuporter buildmaster then hardlinks packages in /var/packages/instances to /var/packages/repository/(branch)/(arch)/current/packages/
-  * This is something performed by haikuporter --create-package-repository called by loop
+  * This is something performed by haikuporter.py --create-package-repository called by loop
 * haikuporter buildmaster then generates a repository for the hardlinked packages in /var/packages/repository/(branch)/(arch)/current/
-  * This is something performed by haikuporter --create-package-repository called by loop
+  * This is something performed by haikuporter.py --create-package-repository called by loop

--- a/buildmaster/backend/assets/bin/buildmaster
+++ b/buildmaster/backend/assets/bin/buildmaster
@@ -52,7 +52,7 @@ case "$1" in
 		fi
 
 		echo "moving from $PREVIOUS_REVISION to $HEAD_REVISION"
-		haikuporter --no-package-obsoletion --repository-update
+		haikuporter.py --no-package-obsoletion --repository-update
 
 		PORTS_TO_BUILD=$(git diff-tree -z -r --name-only --diff-filter ACMTR \
 				$PREVIOUS_REVISION..$HEAD_REVISION \

--- a/buildmaster/backend/assets/bin/buildmaster
+++ b/buildmaster/backend/assets/bin/buildmaster
@@ -56,7 +56,7 @@ case "$1" in
 
 		PORTS_TO_BUILD=$(git diff-tree -z -r --name-only --diff-filter ACMTR \
 				$PREVIOUS_REVISION..$HEAD_REVISION \
-			| xargs --null haikuporter --no-package-obsoletion \
+			| xargs --null haikuporter.py --no-package-obsoletion \
 				--no-repository-update --ports-for-files \
 				--active-versions-only 2> /dev/null \
 			| sort -u)
@@ -69,7 +69,7 @@ case "$1" in
 		fi
 	;;
 	everything)
-		PORTS_TO_BUILD=$(haikuporter --no-package-obsoletion --print-raw \
+		PORTS_TO_BUILD=$(haikuporter.py --no-package-obsoletion --print-raw \
 			--list 2> /dev/null)
 	;;
 	build)
@@ -121,7 +121,7 @@ echo "$BUILDRUN_ID" > "$BUILDRUN_FILE"
 rm "$BUILDRUN_BASE/current"
 ln -rs "$BUILDRUN_OUTPUT_DIR" "$BUILDRUN_BASE/current"
 
-haikuporter --debug --build-master-output-dir="$BUILDRUN_OUTPUT_DIR" \
+haikuporter.py --debug --build-master-output-dir="$BUILDRUN_OUTPUT_DIR" \
 	--system-packages-directory="$SYSTEM_PACKAGES_DIR" \
 	--build-master $PORTS_TO_BUILD
 

--- a/buildmaster/backend/assets/bin/createbuilder
+++ b/buildmaster/backend/assets/bin/createbuilder
@@ -69,7 +69,7 @@ config = {
       "path": args.workdir
     },
     "haikuporter": {
-      "path": "haikuporter",
+      "path": "haikuporter.py",
       "args": ""
     }
   }

--- a/buildmaster/backend/assets/bin/missing_ports.sh
+++ b/buildmaster/backend/assets/bin/missing_ports.sh
@@ -10,7 +10,7 @@ fi
 
 set -e
 
-HAIKUPORTER=${HAIKUPORTER:-haikuporter}
+HAIKUPORTER=${HAIKUPORTER:-haikuporter.py}
 VALID_PACKAGE_LIST=$(mktemp)
 PRESENT_PACKAGE_LIST=$(mktemp)
 

--- a/buildmaster/backend/assets/loop
+++ b/buildmaster/backend/assets/loop
@@ -32,12 +32,12 @@ build_prep () {
 	CONSISTENCY_REPORT_FILE="$REPO_DIR/repo_consistency.txt"
 	echo "repo consistency report at $(git rev-parse HEAD)" \
 		> "$CONSISTENCY_REPORT_FILE"
-	haikuporter --debug --check-repository-consistency \
+	haikuporter.py --debug --check-repository-consistency \
 		--no-package-obsoletion \
 		--system-packages-directory $SYSTEM_PACKAGES_DIR \
 		>> "$CONSISTENCY_REPORT_FILE" 2>&1
 
-	haikuporter --debug --prune-package-repository
+	haikuporter.py --debug --prune-package-repository
 }
 
 while true
@@ -107,7 +107,7 @@ do
 
 	echo ""
 	echo "$(date) pruning packages and creating repository"
-	haikuporter --debug --prune-package-repository \
+	haikuporter.py --debug --prune-package-repository \
 		--system-packages-directory $SYSTEM_PACKAGES_DIR \
 		--check-package-repository-consistency \
 		--create-package-repository "$REPO_DIR" \

--- a/doc/haikuporter_bash_completion
+++ b/doc/haikuporter_bash_completion
@@ -41,4 +41,4 @@ function _haikuporter()
 
 	return 0
 }
-complete -F _haikuporter -o filenames haikuporter
+complete -F _haikuporter.py -o filenames haikuporter

--- a/doc/haikuporter_bash_completion
+++ b/doc/haikuporter_bash_completion
@@ -5,7 +5,7 @@
 
 function _hp_options
 {
-local options="$(haikuporter -h | grep -- -- | cut -f3,4 -d' ' | sed -e 's/, / /')"
+local options="$(haikuporter.py -h | grep -- -- | cut -f3,4 -d' ' | sed -e 's/, / /')"
 COMPREPLY=(${COMPREPLY[@]:-} $(compgen -W '$options' -- "$cur"))
 }
 
@@ -13,7 +13,7 @@ function _hp_beps
 {
 	local packages
 
-	for i in "$(haikuporter -t)"/*/*/*.bep; do
+	for i in "$(haikuporter.py -t)"/*/*/*.bep; do
 		i="${i##*/}"
 		packages="${i%.bep} ${packages}"
 	done

--- a/haikuports-sample.conf
+++ b/haikuports-sample.conf
@@ -18,7 +18,7 @@
 #	function inrecipe { find /path/to/your/haikuports -maxdepth 3 \
 #            -name "*.recipe" | xargs grep -ni --col $1; }
 #
-#	alias hp="haikuporter -S -j8 --no-source-packages --get-dependencies"
+#	alias hp="haikuporter.py -S -j8 --no-source-packages --get-dependencies"
 
 # ==================
 # Required settings:

--- a/haikuports.conf
+++ b/haikuports.conf
@@ -1,0 +1,73 @@
+# Example HaikuPorts configuration
+#
+# =============
+# Installation:
+#   1) cp haikuports-sample.conf ~/config/settings/haikuports.conf
+#
+#   2) customize your settings:
+#      lpe ~/config/settings/haikuports.conf
+
+# ==================
+# Tip:
+#
+# Put this into your ~/config/settings/profile to search for a string in all
+# recipes with "inrecipe {searchstring}" and build a package with
+# "hp {packagename}" (adjust your /path/to/your/haikuports/):
+#
+#	function inpatch () { grep -rni $1 /path/to/your/haikuports/*/*/patches/*; }
+#	function inrecipe { find /path/to/your/haikuports -maxdepth 3 \
+#            -name "*.recipe" | xargs grep -ni --col $1; }
+#
+#	alias hp="haikuporter.py -S -j8 --no-source-packages --get-dependencies"
+
+# ==================
+# Required settings:
+#
+
+# --------------
+# TREE_PATH:
+#     The full path to your cloned haikuports tree.
+TREE_PATH="/Users/jurgenwigg/GitProjects/GitHub/haikuports"
+
+# --------------
+# PACKAGER:
+#     Your name and email
+PACKAGER="Jurgen Wigg <jurgenwigg@protonmail.com>"
+
+# ==================
+# Optional settings:
+
+# --------------
+# VENDOR:
+#     Sets a custom VENDOR tag that will be inserted into all built packages
+#     ("Haiku Project" by default).
+#VENDOR="Haiku Project"
+
+# --------------
+# ALLOW_UNTESTED:
+#     Allow build of untested recipes. '?x86' for example
+#ALLOW_UNTESTED="yes"
+
+# --------------
+# ALLOW_UNSAFE_SOURCES:
+#     Allow building from unsafe sources. Setting this to yes allows
+#     downloading sources for which there is no possibility to check if they
+#     have been corrupted or tampered with.
+#
+#     Only set this to yes if you really need this and know what you're doing,
+#     for example if you want to build recipes for development versions that
+#     fetch the head from a repository.
+#ALLOW_UNSAFE_SOURCES="yes"
+
+# --------------
+# TARGET_ARCHITECTURE:
+#     The primary architectures you wish to compile recipes for.
+#     Defaults to the current primary platform.
+TARGET_ARCHITECTURE="x86"
+
+# --------------
+# SECONDARY_TARGET_ARCHITECTURES:
+#     Secondary platforms you wish to build packages for (one per line)
+#     Example is x86 (gcc4) packages on a x86_gcc2 (gcc2) system
+#     Default is no secondary target architectures.
+#SECONDARY_TARGET_ARCHITECTURES="x86"


### PR DESCRIPTION
While making the package modern I've changed filename of `haikuporter` to `haikuporter.py`. I didn't notice that this script is included in other places and is actively used by the scripts. I've changed all occurrences of script file name that is appearing in other files.