### PR TITLE
Import statements sorted with isort and fixed MockBuilder.py

### DIFF
--- a/HaikuPorter/BuildMaster.py
+++ b/HaikuPorter/BuildMaster.py
@@ -7,23 +7,23 @@
 
 # -- Modules ------------------------------------------------------------------
 
-from .Configuration import Configuration
-from .Options import getOption
-from .Port import Port
-from .ReporterMongo import ReporterMongo
-from .ReporterJson import ReporterJson
-from .Utils import ensureCommandIsAvailable, sysExit, warn, info
-
-from .Builders.Builder import _BuilderState
-from .Builders.LocalBuilder import LocalBuilder
-from .Builders.RemoteBuilderSSH import RemoteBuilderSSH
-
 import json
 import logging
 import os
 import subprocess
 import threading
 import time
+
+from .Builders.Builder import _BuilderState
+from .Builders.LocalBuilder import LocalBuilder
+from .Builders.RemoteBuilderSSH import RemoteBuilderSSH
+from .Configuration import Configuration
+from .Options import getOption
+from .Port import Port
+from .ReporterJson import ReporterJson
+from .ReporterMongo import ReporterMongo
+from .Utils import ensureCommandIsAvailable, info, sysExit, warn
+
 
 class ThreadFilter(object):
 	def __init__(self):

--- a/HaikuPorter/BuildPlatform.py
+++ b/HaikuPorter/BuildPlatform.py
@@ -5,13 +5,6 @@
 
 # -- Modules ------------------------------------------------------------------
 
-from .Configuration import Configuration
-from .DependencyResolver import DependencyResolver
-from .Options import getOption
-from .PackageInfo import PackageInfo
-from .RecipeTypes import Architectures, MachineArchitecture
-from .Utils import sysExit, info
-
 import os
 import platform
 import shutil
@@ -19,6 +12,12 @@ import sys
 import time
 from subprocess import check_output
 
+from .Configuration import Configuration
+from .DependencyResolver import DependencyResolver
+from .Options import getOption
+from .PackageInfo import PackageInfo
+from .RecipeTypes import Architectures, MachineArchitecture
+from .Utils import info, sysExit
 
 buildPlatform = None
 

--- a/HaikuPorter/Builders/LocalBuilder.py
+++ b/HaikuPorter/Builders/LocalBuilder.py
@@ -12,6 +12,7 @@ import time
 
 from .Builder import _BuilderState
 
+
 class LocalBuilder(object):
 	def __init__(self, name, packagesPath, outputBaseDir, options):
 		self.options = options

--- a/HaikuPorter/Builders/MockBuilder.py
+++ b/HaikuPorter/Builders/MockBuilder.py
@@ -5,6 +5,9 @@
 # Distributed under the terms of the MIT License.
 
 
+import time
+
+
 class MockBuilder(object):
 	def __init__(self, name, buildFailInterval, builderFailInterval, lostAfter):
 		self.name = name
@@ -54,3 +57,4 @@ class MockBuilder(object):
 		return {
 			'name': self.name,
 			'lost': self.lost,
+		}

--- a/HaikuPorter/Builders/RemoteBuilderSSH.py
+++ b/HaikuPorter/Builders/RemoteBuilderSSH.py
@@ -12,11 +12,10 @@ import socket
 import stat
 import time
 
-from .Builder import _BuilderState
-
 # These usages kinda need refactored
 from ..ConfigParser import ConfigParser
 from ..Configuration import Configuration
+from .Builder import _BuilderState
 
 try:
 	import paramiko

--- a/HaikuPorter/ConfigParser.py
+++ b/HaikuPorter/ConfigParser.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 # -*- coding: utf-8 -*-
 #
 # Copyright 2013 Oliver Tappe
@@ -6,30 +5,14 @@ from __future__ import absolute_import
 
 # -- Modules ------------------------------------------------------------------
 
-from subprocess import CalledProcessError, check_output
 import functools
+from subprocess import CalledProcessError, check_output
 
-from .RecipeTypes import (
-	Architectures,
-	Extendable,
-	LinesOfText,
-	MachineArchitecture,
-	Phase,
-	ProvidesList,
-	RequiresList,
-	Status,
-	YesNo,
-)
-from .ShellScriptlets import (
-	configFileEvaluatorScript,
-	getShellVariableSetters,
-)
-from .Utils import (
-	filteredEnvironment,
-	sysExit,
-	warn,
-)
-
+from .RecipeTypes import (Architectures, Extendable, LinesOfText,
+                          MachineArchitecture, Phase, ProvidesList,
+                          RequiresList, Status, YesNo)
+from .ShellScriptlets import configFileEvaluatorScript, getShellVariableSetters
+from .Utils import filteredEnvironment, sysExit, warn
 
 # -- haikuports.conf and *.recipe parser --------------------------------
 

--- a/HaikuPorter/Configuration.py
+++ b/HaikuPorter/Configuration.py
@@ -6,13 +6,14 @@
 
 # -- Modules ------------------------------------------------------------------
 
-from .ConfigParser import ConfigParser
-from .Options import getOption
-from .RecipeTypes import (Extendable, MachineArchitecture, YesNo)
-from .Utils import sysExit
-
 import os
 import re
+
+from .ConfigParser import ConfigParser
+from .Options import getOption
+from .RecipeTypes import Extendable, MachineArchitecture, YesNo
+from .Utils import sysExit
+
 
 def which(program):
 	def isExecutable(path):

--- a/HaikuPorter/DependencyAnalyzer.py
+++ b/HaikuPorter/DependencyAnalyzer.py
@@ -6,17 +6,17 @@
 
 # -- Modules ------------------------------------------------------------------
 
-from .BuildPlatform import buildPlatform
-from .Options import getOption
-from .PackageInfo import (PackageInfo, ResolvableExpression)
-from .ProvidesManager import ProvidesManager
-from .ShellScriptlets import getScriptletPrerequirements
-from .Utils import sysExit
-
 import copy
 import os
 import shutil
 from subprocess import CalledProcessError
+
+from .BuildPlatform import buildPlatform
+from .Options import getOption
+from .PackageInfo import PackageInfo, ResolvableExpression
+from .ProvidesManager import ProvidesManager
+from .ShellScriptlets import getScriptletPrerequirements
+from .Utils import sysExit
 
 # -----------------------------------------------------------------------------
 

--- a/HaikuPorter/DependencyResolver.py
+++ b/HaikuPorter/DependencyResolver.py
@@ -15,6 +15,7 @@ from .ProvidesManager import ProvidesManager
 from .ShellScriptlets import getScriptletPrerequirements
 from .Utils import printError, sysExit, warn
 
+
 class RestartDependencyResolutionException(Exception):
 	def __init__(self, packageNode, message):
 		Exception.__init__(self)

--- a/HaikuPorter/Display.py
+++ b/HaikuPorter/Display.py
@@ -9,6 +9,7 @@ import curses
 import datetime
 import time
 
+
 class DisplayContext(object):
 	def __init__(self):
 		self.stdscr = None

--- a/HaikuPorter/Main.py
+++ b/HaikuPorter/Main.py
@@ -12,22 +12,23 @@
 
 # -- Modules ------------------------------------------------------------------
 
+import os
+import re
+import sys
+import traceback
+from subprocess import check_call
+
 from .BuildPlatform import buildPlatform
 from .Configuration import Configuration
 from .DependencyAnalyzer import DependencyAnalyzer
 from .Options import getOption
-from .Policy import Policy
 from .PackageRepository import PackageRepository
+from .Policy import Policy
 from .RecipeAttributes import getRecipeFormatVersion
 from .RecipeTypes import MachineArchitecture
 from .Repository import Repository
-from .Utils import ensureCommandIsAvailable, haikuportsRepoUrl, sysExit, warn, info
-
-import os
-import re
-from subprocess import check_call
-import sys
-import traceback
+from .Utils import (ensureCommandIsAvailable, haikuportsRepoUrl, info, sysExit,
+                    warn)
 
 # -- Main Class ---------------------------------------------------------------
 

--- a/HaikuPorter/Options.py
+++ b/HaikuPorter/Options.py
@@ -13,12 +13,11 @@
 
 # -- Modules ------------------------------------------------------------------
 
+from multiprocessing import cpu_count
+from optparse import OptionGroup, OptionParser
+
 from .__version__ import __version__
 from .Utils import isCommandAvailable, warn
-
-from optparse import OptionParser, OptionGroup
-from multiprocessing import cpu_count
-
 
 # -- global options -----------------------------------------------------------
 

--- a/HaikuPorter/Package.py
+++ b/HaikuPorter/Package.py
@@ -12,6 +12,14 @@
 
 # -- Modules ------------------------------------------------------------------
 
+import codecs
+import datetime
+import json
+import os
+import shutil
+from functools import cmp_to_key
+from subprocess import STDOUT, CalledProcessError, check_call, check_output
+
 from .BuildPlatform import buildPlatform
 from .ConfigParser import ConfigParser
 from .Configuration import Configuration
@@ -19,17 +27,8 @@ from .Options import getOption
 from .RecipeTypes import Architectures, Status
 from .ShellScriptlets import getScriptletPrerequirements
 from .Utils import (ensureCommandIsAvailable, escapeForPackageInfo,
-					haikuporterRepoUrl, haikuportsRepoUrl, info, naturalCompare,
-					sysExit, touchFile, warn)
-
-import codecs
-from functools import cmp_to_key
-import datetime
-import json
-import os
-import shutil
-from subprocess import check_call, check_output, CalledProcessError, STDOUT
-
+                    haikuporterRepoUrl, haikuportsRepoUrl, info,
+                    naturalCompare, sysExit, touchFile, warn)
 
 # -- The supported package types ----------------------------------------------
 

--- a/HaikuPorter/PackageInfo.py
+++ b/HaikuPorter/PackageInfo.py
@@ -5,17 +5,16 @@
 
 # -- Modules ------------------------------------------------------------------
 
-from .Configuration import Configuration
-from .Utils import sysExit
-
-from copy import deepcopy
-from subprocess import check_output
 import codecs
 import json
 import os
 import pickle
 import re
+from copy import deepcopy
+from subprocess import check_output
 
+from .Configuration import Configuration
+from .Utils import sysExit
 
 # -- Resolvable class ---------------------------------------------------------
 

--- a/HaikuPorter/PackageRepository.py
+++ b/HaikuPorter/PackageRepository.py
@@ -5,17 +5,16 @@
 
 # -- Modules ------------------------------------------------------------------
 
-from .Configuration import Configuration
-from .DependencyResolver import DependencyResolver
-from .PackageInfo import PackageInfo
-from .Options import getOption
-from .Utils import info, prefixLines, sysExit, versionCompare, warn
-
 import glob
 import hashlib
 import os
 import subprocess
 
+from .Configuration import Configuration
+from .DependencyResolver import DependencyResolver
+from .Options import getOption
+from .PackageInfo import PackageInfo
+from .Utils import info, prefixLines, sysExit, versionCompare, warn
 
 # -- PackageRepository class --------------------------------------------------
 

--- a/HaikuPorter/Policy.py
+++ b/HaikuPorter/Policy.py
@@ -5,14 +5,14 @@
 
 # -- Modules ------------------------------------------------------------------
 
+import glob
+import os
+import re
+from subprocess import check_output
+
 from .ConfigParser import ConfigParser
 from .Configuration import Configuration
 from .Utils import isCommandAvailable, sysExit, warn
-
-from subprocess import check_output
-import os
-import re
-import glob
 
 allowedWritableTopLevelDirectories = [
 	'cache',

--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -13,51 +13,30 @@
 # -- Modules ------------------------------------------------------------------
 
 import codecs
-from functools import cmp_to_key
 import json
 import os
 import re
 import shutil
 import signal
-from subprocess import check_call, check_output, CalledProcessError, Popen, \
-	PIPE, STDOUT
 import traceback
+from functools import cmp_to_key
+from subprocess import (PIPE, STDOUT, CalledProcessError, Popen, check_call,
+                        check_output)
 
 from .BuildPlatform import buildPlatform
 from .ConfigParser import ConfigParser
 from .Configuration import Configuration
 from .Options import getOption
-from .Package import (
-	PackageType,
-	sourcePackageFactory,
-	packageFactory,
-)
+from .Package import PackageType, packageFactory, sourcePackageFactory
 from .RecipeAttributes import getRecipeAttributes
-from .RecipeTypes import (
-	Extendable,
-	MachineArchitecture,
-	Phase,
-	Status)
+from .RecipeTypes import Extendable, MachineArchitecture, Phase, Status
 from .ReleaseChecker import createReleaseChecker
 from .RequiresUpdater import RequiresUpdater
-from .ShellScriptlets import (
-	cleanupChrootScript,
-	getShellVariableSetters,
-	recipeActionScript,
-	setupChrootScript,
-)
+from .ShellScriptlets import (cleanupChrootScript, getShellVariableSetters,
+                              recipeActionScript, setupChrootScript)
 from .Source import Source
-from .Utils import (
-	filteredEnvironment,
-	info,
-	naturalCompare,
-	storeStringInFile,
-	symlinkGlob,
-	sysExit,
-	touchFile,
-	warn,
-)
-
+from .Utils import (filteredEnvironment, info, naturalCompare,
+                    storeStringInFile, symlinkGlob, sysExit, touchFile, warn)
 
 # -- Modules preloaded for chroot ---------------------------------------------
 # These modules need to be preloaded in order to avoid problems with python

--- a/HaikuPorter/ProvidesManager.py
+++ b/HaikuPorter/ProvidesManager.py
@@ -7,7 +7,6 @@
 # -- Modules ------------------------------------------------------------------
 
 from . import BuildPlatform
-
 from .Configuration import Configuration
 from .Options import getOption
 from .PackageInfo import PackageInfo, Resolvable

--- a/HaikuPorter/RecipeAttributes.py
+++ b/HaikuPorter/RecipeAttributes.py
@@ -12,11 +12,11 @@
 
 # -- Modules ------------------------------------------------------------------
 
-from .Package import PackageType
-from .RecipeTypes import (Architectures, Extendable, LinesOfText,
-						  Phase, ProvidesList, RequiresList, YesNo)
 import copy
 
+from .Package import PackageType
+from .RecipeTypes import (Architectures, Extendable, LinesOfText, Phase,
+                          ProvidesList, RequiresList, YesNo)
 
 # -- recipe keys and their attributes -----------------------------------------
 

--- a/HaikuPorter/ReporterJson.py
+++ b/HaikuPorter/ReporterJson.py
@@ -11,6 +11,7 @@
 import json
 import os
 
+
 class ReporterJson(object):
 	def __init__(self, filename, branch, architecture):
 		self.filename = filename

--- a/HaikuPorter/ReporterMongo.py
+++ b/HaikuPorter/ReporterMongo.py
@@ -5,7 +5,7 @@
 #
 # Authors:
 #   Alexander von Gluck IV <kallisti5@unixzen.com>
-from .Utils import warn, info
+from .Utils import info, warn
 
 try:
 	from pymongo import MongoClient

--- a/HaikuPorter/Repository.py
+++ b/HaikuPorter/Repository.py
@@ -5,22 +5,21 @@
 
 # -- Modules ------------------------------------------------------------------
 
-from .Configuration import Configuration
-from .DependencyResolver import DependencyResolver
-from .Options import getOption
-from .Port import Port
-from .Utils import prefixLines, sysExit, touchFile, versionCompare, warn
-
 import codecs
-from functools import cmp_to_key
 import glob
 import json
 import os
 import re
 import shutil
+from functools import cmp_to_key
 from subprocess import check_call, check_output
 from textwrap import dedent
 
+from .Configuration import Configuration
+from .DependencyResolver import DependencyResolver
+from .Options import getOption
+from .Port import Port
+from .Utils import prefixLines, sysExit, touchFile, versionCompare, warn
 
 # -- Repository class ---------------------------------------------------------
 

--- a/HaikuPorter/RequiresUpdater.py
+++ b/HaikuPorter/RequiresUpdater.py
@@ -5,12 +5,12 @@
 
 # -- Modules ------------------------------------------------------------------
 
+import os
+from subprocess import CalledProcessError
+
 from .PackageInfo import PackageInfo, Resolvable, ResolvableExpression
 from .ProvidesManager import ProvidesManager
 from .Utils import sysExit
-
-import os
-from subprocess import CalledProcessError
 
 # -- ProvidesInfo class -------------------------------------------------------
 

--- a/HaikuPorter/Source.py
+++ b/HaikuPorter/Source.py
@@ -12,18 +12,17 @@
 
 # -- Modules ------------------------------------------------------------------
 
-from .Configuration import Configuration
-from .Options import getOption
-from .SourceFetcher import (createSourceFetcher, foldSubdirIntoSourceDir,
-							parseCheckoutUri)
-from .Utils import (ensureCommandIsAvailable, info, readStringFromFile,
-					storeStringInFile, sysExit, warn)
-
 import hashlib
 import os
 import shutil
-from subprocess import check_call, check_output, CalledProcessError
+from subprocess import CalledProcessError, check_call, check_output
 
+from .Configuration import Configuration
+from .Options import getOption
+from .SourceFetcher import (createSourceFetcher, foldSubdirIntoSourceDir,
+                            parseCheckoutUri)
+from .Utils import (ensureCommandIsAvailable, info, readStringFromFile,
+                    storeStringInFile, sysExit, warn)
 
 # -- A source archive (or checkout) -------------------------------------------
 

--- a/HaikuPorter/SourceFetcher.py
+++ b/HaikuPorter/SourceFetcher.py
@@ -12,15 +12,14 @@
 
 # -- Modules ------------------------------------------------------------------
 
-from .Configuration import Configuration
-from .Utils import ensureCommandIsAvailable, info, sysExit, unpackArchive, warn
-
 import os
 import re
 import shutil
-from subprocess import CalledProcessError, check_output, PIPE, Popen, STDOUT
 import time
+from subprocess import PIPE, STDOUT, CalledProcessError, Popen, check_output
 
+from .Configuration import Configuration
+from .Utils import ensureCommandIsAvailable, info, sysExit, unpackArchive, warn
 
 # -----------------------------------------------------------------------------
 

--- a/HaikuPorter/Utils.py
+++ b/HaikuPorter/Utils.py
@@ -12,11 +12,11 @@ import logging
 import os
 import re
 import shutil
-from subprocess import PIPE, Popen
 import sys
 import tarfile
 import time
 import zipfile
+from subprocess import PIPE, Popen
 
 if sys.stdout.isatty():
 	colorWarning = '\033[1;36m'


### PR DESCRIPTION
- Import statements sorted with `isort` command. 
- `MockBuilder.py` fixed:
  - Fixed missing closing bracket at the end of the file
  - Fixed missing import
- Removed unnecessary (correct my if I'm wrong) import statement `from __future__ import absolute_import` from `ConfigParser.py`. 

**Open point**
Maybe someone will know - what was the reason for using `absolute_import` in `ConfigParser.py`? 

Please remember to tick the checkbox for squashing commits before merging PR to master (I forgot to do that and I don't have a possibility to change it after creating the PR).