### PR TITLE
BuildPlatform: assume python3 is available on Unix build host

### DIFF
--- a/HaikuPorter/BuildPlatform.py
+++ b/HaikuPorter/BuildPlatform.py
@@ -319,6 +319,7 @@ class BuildPlatformUnix(BuildPlatform):
 			'cmd:objcopy',
 			'cmd:passwd',
 			'cmd:perl',
+			'cmd:python3',
 			'cmd:ranlib',
 			'cmd:readelf',
 			'cmd:sed',


### PR DESCRIPTION
one more for the bootstrap build... haikuporter itself is a python3 script so it's pretty much straightforward to assume that the build host has python3 available