### PR TITLE
extractPatchset: add git config core.abbrev=auto to format-patch call

### DIFF
--- a/HaikuPorter/Source.py
+++ b/HaikuPorter/Source.py
@@ -433,9 +433,9 @@ class Source(object):
 		if not os.path.exists(patchSetDirectory):
 			os.mkdir(patchSetDirectory)
 		with open(patchSetFilePath, 'w') as patchSetFile:
-			check_call(['git', 'format-patch', '-kp', '--stdout', 'ORIGIN'],
-					   stdout=patchSetFile, cwd=self.sourceDir,
-					   env=self.gitEnv)
+			check_call(['git', '-c', 'core.abbrev=auto', 'format-patch', '-kp',
+					   '--stdout', 'ORIGIN'], stdout=patchSetFile,
+					   cwd=self.sourceDir, env=self.gitEnv)
 
 		if needToRebase:
 			# put PATCH_FUNCTION back in


### PR DESCRIPTION
This makes sure that the patch output is consistent, even if users use different values for that option.

`haikuporter -e` is called by developers and its output ends up in the haikuports repository, so it should be as consistent as possible to avoid unnecessary noise.

Other commands either don't produce any visible output or are run on the buildmaster systems where there is a defined environment, so it isn't necessary to define the git config explicitly.

If there are other options which influence the output of `format-patch`, they should also be set explicitly.