### PR TITLE
Add support for pre-uninstall scripts

### DIFF
--- a/HaikuPorter/Package.py
+++ b/HaikuPorter/Package.py
@@ -400,6 +400,9 @@ class Package(object):
 				self._writePackageInfoListQuotePaths(infoFile,
 					self.recipeKeys['POST_INSTALL_SCRIPTS'],
 					'post-install-scripts')
+				self._writePackageInfoListQuotePaths(infoFile,
+					self.recipeKeys['PRE_UNINSTALL_SCRIPTS'],
+					'pre-uninstall-scripts')
 
 			# Generate SourceURL lines for all ports, regardless of license.
 			# Re-use the download URLs, as specified in the recipe.

--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -1212,6 +1212,7 @@ class Port(object):
 			'documentationDir': 'documentation',
 			'fontsDir': 'data/fonts',
 			'postInstallDir': 'boot/post-install',
+			'preUninstallDir': 'boot/pre-uninstall',
 			'preferencesDir': 'preferences',
 			'settingsDir': 'settings',
 		}

--- a/HaikuPorter/RecipeAttributes.py
+++ b/HaikuPorter/RecipeAttributes.py
@@ -205,6 +205,13 @@ recipeAttributes = {
 		'extendable': Extendable.DEFAULT,
 		'indexable': False,
 	},
+	'PRE_UNINSTALL_SCRIPTS': {
+		'type': list,
+		'required': False,
+		'default': [],
+		'extendable': Extendable.DEFAULT,
+		'indexable': False,
+	},
 	'PROVIDES': {
 		'type': ProvidesList,
 		'required': True,

--- a/HaikuPorter/RecipeAttributes.py
+++ b/HaikuPorter/RecipeAttributes.py
@@ -205,6 +205,13 @@ recipeAttributes = {
 		'extendable': Extendable.DEFAULT,
 		'indexable': False,
 	},
+	'POST_INSTALL_SCRIPTS': {
+		'type': list,
+		'required': False,
+		'default': [],
+		'extendable': Extendable.DEFAULT,
+		'indexable': False,
+	},
 	'PRE_UNINSTALL_SCRIPTS': {
 		'type': list,
 		'required': False,
@@ -216,13 +223,6 @@ recipeAttributes = {
 		'type': ProvidesList,
 		'required': True,
 		'default': None,
-		'extendable': Extendable.DEFAULT,
-		'indexable': False,
-	},
-	'POST_INSTALL_SCRIPTS': {
-		'type': list,
-		'required': False,
-		'default': [],
 		'extendable': Extendable.DEFAULT,
 		'indexable': False,
 	},


### PR DESCRIPTION
This is analoguous to post-install scripts.

Defines a new recipe attribute PRE_UNINSTALL_SCRIPTS and new directory variables $preUninstallDir and $relativePreUninstallDir.

Fixes #306.