### PR TITLE
fix "any" arch subpackages on secondary arch

### DIFF
--- a/HaikuPorter/Package.py
+++ b/HaikuPorter/Package.py
@@ -96,6 +96,8 @@ class Package(object):
 				self.architecture = port.targetArchitecture
 			else:
 				self.architecture = Architectures.SOURCE
+		elif Architectures.ANY in self.recipeKeys['ARCHITECTURES']:
+			self.architecture = Architectures.ANY
 		elif ((port.secondaryArchitecture is not None and
 			  port.secondaryArchitecture in self.recipeKeys['SECONDARY_ARCHITECTURES']) or
 			  port.targetArchitecture in self.recipeKeys['ARCHITECTURES']):
@@ -104,8 +106,6 @@ class Package(object):
 			# is the same as the target architecture, except for "_cross_"
 			# packages, which are built for the host on which the build runs.)
 			self.architecture = port.hostArchitecture
-		elif Architectures.ANY in self.recipeKeys['ARCHITECTURES']:
-			self.architecture = Architectures.ANY
 		else:
 			sysExit('package %s cannot be built for architecture %s'
 					% (self.versionedName, port.targetArchitecture))
@@ -142,8 +142,9 @@ class Package(object):
 
 	def getStatusOnSecondaryArchitecture(self, architecture,
 			secondaryArchitecture):
-		# check the secondary architecture
-		if secondaryArchitecture:
+		# check the secondary architecture (but ANY takes precedence)
+		if (secondaryArchitecture
+			and not Architectures.ANY in self.recipeKeys['ARCHITECTURES']):
 			secondaryStatus = Status.UNSUPPORTED
 			secondaryArchitectures = self.recipeKeys['SECONDARY_ARCHITECTURES']
 			if secondaryArchitecture in secondaryArchitectures:

--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -29,7 +29,7 @@ from .Configuration import Configuration
 from .Options import getOption
 from .Package import PackageType, packageFactory, sourcePackageFactory
 from .RecipeAttributes import getRecipeAttributes
-from .RecipeTypes import Extendable, MachineArchitecture, Phase, Status
+from .RecipeTypes import Architectures, Extendable, MachineArchitecture, Phase, Status
 from .ReleaseChecker import createReleaseChecker
 from .RequiresUpdater import RequiresUpdater
 from .ShellScriptlets import (cleanupChrootScript, getShellVariableSetters,
@@ -1000,10 +1000,12 @@ class Port(object):
 		haveSourcePackage = False
 		for extension in sorted(self.recipeKeysByExtension.keys()):
 			keys = self.recipeKeysByExtension[extension]
-			if extension:
-				name = self.name + '_' + extension
+			if Architectures.ANY in keys['ARCHITECTURES']:
+				name = self.baseName
 			else:
 				name = self.name
+			if extension:
+				name += '_' + extension
 			packageType = PackageType.byName(extension)
 			package = packageFactory(packageType, name, self, keys, self.policy)
 			self.allPackages.append(package)

--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -120,6 +120,7 @@ class Port(object):
 		# build dictionary of variables to inherit to shell
 		self.shellVariables = {
 			'portName': self.name,
+			'portBaseName': self.baseName,
 			'portVersion': self.version,
 			'portVersionedName': self.versionedName,
 			'portBaseDir': self.baseDir,

--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -92,7 +92,7 @@ getPackagePrefix()
 	local packagePrefix="$linksDir/.self"
 	if [ ! -e "$packagePrefix" ]; then
 		# try again with the base name
-		local packageName="${portName/%$secondaryArchSuffix}_$packageSuffix"
+		local packageName="${portBaseName}_$packageSuffix"
 		local linksDir="$packageLinksDir/$packageName-$packageVersion-$REVISION"
 		local packagePrefix="$linksDir/.self"
 		if [ ! -e "$packagePrefix" ]; then

--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -91,8 +91,14 @@ getPackagePrefix()
 	local linksDir="$packageLinksDir/$packageName-$packageVersion-$REVISION"
 	local packagePrefix="$linksDir/.self"
 	if [ ! -e "$packagePrefix" ]; then
-		echo >&2 "packageEntries: warning: \"$packageSuffix\" doesn't seem to be a valid package suffix."
-		exit 1
+		# try again with the base name
+		local packageName="${portName/%$secondaryArchSuffix}_$packageSuffix"
+		local linksDir="$packageLinksDir/$packageName-$packageVersion-$REVISION"
+		local packagePrefix="$linksDir/.self"
+		if [ ! -e "$packagePrefix" ]; then
+			echo >&2 "packageEntries: warning: \"$packageSuffix\" doesn't seem to be a valid package suffix."
+			exit 1
+		fi
 	fi
 
 	echo $packagePrefix


### PR DESCRIPTION
When determining the architecture of a package, check whether it is "any" before checking the secondary architecture.

To make "any" packages identical to the case when not using a secondary architecture, don't include the secondaryArchSuffix in the package name in this case. This is a breaking change! Any packages using this must update the PROVIDES of the subpackage and should add a REPLACES entry to facilitate upgrades.

Add support for this change to ShellScriptlets getPackagePrefix, which is also used by packageEntries.

Fixes #320.