### PR TITLE
disallow PACKAGE_NAME and PACKAGE_VERSION for the main package

### DIFF
--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -264,6 +264,14 @@ class Port(object):
 		# do some checks for each extension (i.e. package), starting with the
 		# base entries (extension '')
 		baseEntries = recipeConfig.getEntriesForExtension('')
+
+		if 'PACKAGE_NAME' in baseEntries:
+			sysExit('setting a custom name for the main package isn\'t supported, '
+				'please rename the recipe instead.')
+		if 'PACKAGE_VERSION' in baseEntries:
+			sysExit('setting a custom version for the main package isn\'t supported, '
+				'please rename the recipe instead.')
+
 		allPatches = []
 
 		## REFACTOR this loop and its children look unrelated


### PR DESCRIPTION
Otherwise we would need to handle them specially, similar to REVISION, to get directory variables and everything else depending on the prefix right. It would make the implementation much more complex for little to no advantages, when the recipe could just be renamed instead.