### PR TITLE
activate build packages for TEST when they were activated for BUILD

### DIFF
--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -1513,8 +1513,8 @@ class Port(object):
 	def _doTestStage(self):
 		"""Test the build results"""
 
-		# activate build package if required at this stage
-		if (self.recipeKeys['BUILD_PACKAGE_ACTIVATION_PHASE'] == Phase.TEST
+		# activate build packages if they were activated in the BUILD stage
+		if (self.recipeKeys['BUILD_PACKAGE_ACTIVATION_PHASE'] == Phase.BUILD
 			and not (getOption('createSourcePackagesForBootstrap')
 				or getOption('createSourcePackages'))):
 			for package in self.packages:


### PR DESCRIPTION
Otherwise, cmake and meson are not found because their full path gets generated into the build files, and this full path uses portPackageLinksDir, as specified in the wrapper shell scriptlets for cmake and meson.

Using BUILD_PACKAGE_ACTIVATION_PHASE="TEST" doesn't make sense anyway, because this would mean that they wouldn't be active during INSTALL, which makes $prefix not exist, so nothing could be installed. (BUILD_PACKAGE_ACTIVATION_PHASE="BUILD" implies that they are active during INSTALL as well.)

Fixes haikuports/haikuports#12518