### PR TITLE
Repository: add a function to purge stale ports

### DIFF
--- a/HaikuPorter/Main.py
+++ b/HaikuPorter/Main.py
@@ -92,6 +92,7 @@ class Main(object):
 			or self.options.location
 			or self.options.buildMaster
 			or self.options.repositoryUpdate
+			or self.options.purgeStalePorts
 			or self.options.prunePackageRepository
 			or self.options.createPackageRepository
 			or self.options.why
@@ -126,6 +127,11 @@ class Main(object):
 
 			if self.options.checkRepositoryConsistency:
 				self.repository.checkRepositoryConsistency(self.options.verbose)
+			return
+
+		if self.options.purgeStalePorts:
+			self._createRepositoryIfNeeded(self.options.quiet)
+			self.repository.purgeStalePorts()
 			return
 
 		if self.options.prunePackageRepository \

--- a/HaikuPorter/Options.py
+++ b/HaikuPorter/Options.py
@@ -290,6 +290,9 @@ def parseOptions():
 	advanced_flags.add_option('--no-repository-update', action='store_true',
 		dest='noRepositoryUpdate', default=False,
 		help='do not update dependency infos in the repository')
+	advanced_flags.add_option('--purge-stale-ports', action='store_true',
+		dest='purgeStalePorts', default=False,
+		help="delete work dirs and downloads of ports which don't exist any more")
 	advanced_flags.add_option('--no-package-obsoletion', action='store_true',
 		dest='noPackageObsoletion', default=False,
 		help='do not move obsolete packages out of packages dir')


### PR DESCRIPTION
i.e. remove the work directories and downloads of old port (versions) which have been removed. A new command line option "--purge-stale-ports" is introduced for this.

To get the sources of ports (and thus which downloads to keep) it must parse all recipes.

Note that this may be a bit destructive if you are switching git branches while working on something!