### PR TITLE
defineDebugInfoPackage: change first argument to basePackageSuffix

### DIFF
--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -110,7 +110,6 @@ defineDebugInfoPackage()
 	fi
 
 	local destDir=$debugInfoDir
-	local debugInfoSuffix="($portRevisionedName)"
 	if [ "$1" = "--directory" ]; then
 		destDir="$2"
 		shift 2
@@ -122,6 +121,7 @@ defineDebugInfoPackage()
 	if [ -z "$basePackageSuffix" ]; then
 		local basePackageName=$portName
 		local basePackageVersion=$portVersion
+		local debugInfoSuffix="($portRevisionedName)"
 		local packageSuffix=debuginfo
 	else
 		eval "local basePackageName=\"\$PACKAGE_NAME_$basePackageSuffix\""
@@ -132,6 +132,7 @@ defineDebugInfoPackage()
 		if [ -z "$basePackageVersion" ]; then
 			local basePackageVersion=$portVersion
 		fi
+		local debugInfoSuffix="($basePackageName-$basePackageVersion-$REVISION)"
 		local packageSuffix=${basePackageSuffix}_debuginfo
 	fi
 	eval "local packageName=\"\$PACKAGE_NAME_$packageSuffix\""

--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -102,10 +102,10 @@ getPackagePrefix()
 defineDebugInfoPackage()
 {
 	# Usage: defineDebugInfoPackage [ --directory <toDirectory> ]
-	#	<basePackageName> <path> ...
+	#	<basePackageSuffix> <path> ...
 	if [ $# -lt 2 -o "$1" = "--directory" -a $# -lt 4 ]; then
-		echo >&2 "Usage: defineDebugInfoPackage [ --directory <toDirectory> ]"
-			"<packageSuffix> <path> ..."
+		echo >&2 "Usage: defineDebugInfoPackage [ --directory <toDirectory> ]" \
+			"<basePackageSuffix> <path> ..."
 		exit 1
 	fi
 
@@ -116,16 +116,37 @@ defineDebugInfoPackage()
 		shift 2
 	fi
 
-	local basePackageName=$1
+	local basePackageSuffix=$1
 	shift 1
 
-	local packageName=${basePackageName}_debuginfo
-	local packageSuffix=debuginfo
+	if [ -z "$basePackageSuffix" ]; then
+		local basePackageName=$portName
+		local basePackageVersion=$portVersion
+		local packageSuffix=debuginfo
+	else
+		eval "local basePackageName=\"\$PACKAGE_NAME_$basePackageSuffix\""
+		if [ -z "$basePackageName" ]; then
+			local basePackageName=${portName}_$basePackageSuffix
+		fi
+		eval "local basePackageVersion=\"\$PACKAGE_VERSION_$basePackageSuffix\""
+		if [ -z "$basePackageVersion" ]; then
+			local basePackageVersion=$portVersion
+		fi
+		local packageSuffix=${basePackageSuffix}_debuginfo
+	fi
+	eval "local packageName=\"\$PACKAGE_NAME_$packageSuffix\""
+	if [ -z "$packageName" ]; then
+		local packageName=${basePackageName}_debuginfo
+	fi
+	eval "local packageVersion=\"\$PACKAGE_VERSION_$packageSuffix\""
+	if [ -z "$packageVersion" ]; then
+		local packageVersion=$portVersion
+	fi
 
 	local provides=PROVIDES_$packageSuffix
 	local requires=REQUIRES_$packageSuffix
-	printf -v $provides "%s" "${packageName} = $portVersion"
-	printf -v $requires "%s" "${basePackageName} == $portVersion base"
+	printf -v $provides "%s" "${packageName} = $packageVersion"
+	printf -v $requires "%s" "${basePackageName} == $basePackageVersion base"
 
 	# Use two array variables for a path->debugInfo map. An associative array
 	# would be nicer, but we can't declare that to be global before bash 4.2
@@ -142,7 +163,7 @@ defineDebugInfoPackage()
 		local entityName=$(basename $path)
 		local providesEntity="debuginfo:${entityName//-/_}($basePackageName)"
 		printf -v $provides "%s\n%s" "${!provides}" \
-			"\"$providesEntity\" = $portVersion"
+			"\"$providesEntity\" = $packageVersion"
 
 		local debugInfo="$destDir/$(basename $path)$debugInfoSuffix.debuginfo"
 		eval "local count=\${#$paths[*]}"

--- a/generic/generic_cmd-1.2.3.recipe
+++ b/generic/generic_cmd-1.2.3.recipe
@@ -38,7 +38,7 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
-defineDebugInfoPackage projectx \
+defineDebugInfoPackage "" \
 	$binDir/projectx
 
 BUILD()

--- a/generic/generic_cmd_secondary_arch-1.2.3.recipe
+++ b/generic/generic_cmd_secondary_arch-1.2.3.recipe
@@ -47,7 +47,7 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
-defineDebugInfoPackage projectx \
+defineDebugInfoPackage "" \
 	$commandBinDir/projectx
 
 BUILD()

--- a/generic/generic_haiku_app-1.2.3.recipe
+++ b/generic/generic_haiku_app-1.2.3.recipe
@@ -40,7 +40,7 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
-defineDebugInfoPackage projectx \
+defineDebugInfoPackage "" \
 	$appsDir/ProjectX
 
 BUILD()

--- a/generic/generic_haiku_app_secondary_arch-1.2.3.recipe
+++ b/generic/generic_haiku_app_secondary_arch-1.2.3.recipe
@@ -41,7 +41,7 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
-defineDebugInfoPackage projectx$secondaryArchSuffix \
+defineDebugInfoPackage "" \
 	$appsDir/ProjectX
 
 BUILD()

--- a/generic/generic_lib-1.2.3.recipe
+++ b/generic/generic_lib-1.2.3.recipe
@@ -49,7 +49,7 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
-defineDebugInfoPackage projectx$secondaryArchSuffix \
+defineDebugInfoPackage "" \
 	"$libDir"/libprojectx.so.$libVersion \
 	"$libDir"/libprojectx_1.so.$libVersion
 

--- a/tools/cargo-to-recipe.sh
+++ b/tools/cargo-to-recipe.sh
@@ -298,7 +298,7 @@ BUILD_PREREQUIRES="
 	cmd:gcc\$secondaryArchSuffix
 	"
 
-defineDebugInfoPackage $portName\$secondaryArchSuffix \\
+defineDebugInfoPackage \"\" \\
 	\$prefix/bin/$cmd
 
 BUILD()


### PR DESCRIPTION
This allows defining multiple debuginfo packages by not hard-coding the used packageSuffix for the debuginfo package any more but deriving it from the basePackageSuffix instead.

**Note: This is a breaking change!** All invocations of defineDebugInfoPackage in haikuports must be changed. The default case to define the main debuginfo package is to use an empty string (i.e. "") as the first argument now. To define a debuginfo package for a subpackage, use its package suffix instead (similar to packageEntries and getPackagePrefix).

Also adds support for PACKAGE_NAME and PACKAGE_VERSION overrides, both for the referenced base package and the debuginfo package itself. In both cases, they must be declared before defineDebugInfoPackage is called.

Fixes #348.

----

Question: should the `debugInfoSuffix` also be changed for subpackages? (i.e. the base package name and version that is added to debug info file names)