### PR TITLE
meson: Exclude submodule from triggering the --buildtype check

### DIFF
--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -384,7 +384,8 @@ cmake()
 meson()
 {
 	if [[ "$*" != *buildtype* ]] && [[ "$*" != compile* ]] \
-			&& [[ "$*" != install* ]] && [[ "$*" != test* ]]; then
+			&& [[ "$*" != install* ]] && [[ "$*" != test* ]] \
+			&& [[ "$*" != submodule* ]]; then
 		echo "error: invoking meson without --buildtype argument"
 		echo "note: you probably want --buildtype=release or --buildtype=debugoptimized"
 		exit 1


### PR DESCRIPTION
Required for a new port that I'm going to release soon (I can just use /bin/meson to avoid it, but I figured that I should push this fix)