### PR TITLE
cargo-to-recipe.sh Set architecture to x86_64 only (no rust on other architectures)

### DIFF
--- a/tools/cargo-to-recipe.sh
+++ b/tools/cargo-to-recipe.sh
@@ -243,10 +243,10 @@ $(
 	printf '%s\n' "${merged[@]}" | sed '0~'"$psd"' a\\'
 )
 
-ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+ARCHITECTURES="!all x86_64"
 commandBinDir=\$binDir
 if [ "\$targetArchitecture" = x86_gcc2 ]; then
-SECONDARY_ARCHITECTURES="?x86"
+SECONDARY_ARCHITECTURES="!x86"
 commandBinDir=\$prefix/bin
 fi
 


### PR DESCRIPTION
Also use "?all" as per newer setup