### PR TITLE
pyproject.toml: add script declaration to install haikuporter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ mkdocs = "^1.4.2"
 mkdocs-material = "^8.5.10"
 mkdocstrings = {extras = ["python"], version = "^0.19.0"}
 
+[tool.poetry.scripts]
+haikuporter = {reference = "haikuporter", type = "file"}
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Apparently, poetry does support installing existing raw files as scripts. See https://python-poetry.org/docs/pyproject/#scripts-1

This should fix #277.

----

I do agree with @OscarL that poetry has too many dependencies, which we probably will not need. Should we maybe switch the build backend back to setuptools? I would keep `pyproject.toml` though. Setuptools seems to also still support raw scripts, although it is discouraged. See https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration (the `script-files` option).