### PR TITLE
ShellScriptlets: don't check whether package prefixes exist

### DIFF
--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -82,7 +82,12 @@ getPackagePrefix()
 	local packageLinksDir="$(dirname $installDestDir$portPackageLinksDir)"
 	eval "local packageName=\"\$PACKAGE_NAME_$packageSuffix\""
 	if [ -z "$packageName" ]; then
-		local packageName="${portName}_$packageSuffix"
+		eval "local packageArchitectures=\"\$ARCHITECTURES_$packageSuffix\""
+		if [[ "$packageArchitectures" == *any* ]]; then
+			local packageName="${portBaseName}_$packageSuffix"
+		else
+			local packageName="${portName}_$packageSuffix"
+		fi
 	fi
 	eval "local packageVersion=\"\$PACKAGE_VERSION_$packageSuffix\""
 	if [ -z "$packageVersion" ]; then
@@ -90,16 +95,6 @@ getPackagePrefix()
 	fi
 	local linksDir="$packageLinksDir/$packageName-$packageVersion-$REVISION"
 	local packagePrefix="$linksDir/.self"
-	if [ ! -e "$packagePrefix" ]; then
-		# try again with the base name
-		local packageName="${portBaseName}_$packageSuffix"
-		local linksDir="$packageLinksDir/$packageName-$packageVersion-$REVISION"
-		local packagePrefix="$linksDir/.self"
-		if [ ! -e "$packagePrefix" ]; then
-			echo >&2 "packageEntries: warning: \"$packageSuffix\" doesn't seem to be a valid package suffix."
-			exit 1
-		fi
-	fi
 
 	echo $packagePrefix
 }


### PR DESCRIPTION
The check doesn't work outside the chroot (it would require the package in question to be installed locally), so it caused many warnings when getPackagePrefix is used in e.g. defineDebugInfoPackage.

Instead of checking the existence and probing a second time using $portBaseName, check whether the package is an "any" arch package and use $portBaseName in the first place. Note that when the base package is "any", no check is necessary because $portName and $portBaseName are the same in this case anyway.