### PR TITLE
Allow the "all" architecture macro to appear anywhere

### DIFF
--- a/HaikuPorter/ConfigParser.py
+++ b/HaikuPorter/ConfigParser.py
@@ -186,11 +186,9 @@ class ConfigParser(object):
 						architecture = value
 					knownArchitectures = Architectures.getAll()
 					if architecture == 'all':
-						if len(entries[key]) > 0:
-							sysExit("%s specifies 'all' after other architectures"
-									% (filename))
 						for machineArch in MachineArchitecture.getAll():
-							entries[key][machineArch] = status
+							if machineArch not in entries[key]:
+								entries[key][machineArch] = status
 					else:
 						if architecture not in knownArchitectures:
 							architectures = ','.join(knownArchitectures)


### PR DESCRIPTION
"all" now only sets architecture entries that haven't been set explicitly before yet. This allows it to occur anywhere in the list again. Architectures which come before "all" are not overwritten by it, but those coming after it still override the defaults set by "all".

This is a better fix for #339.

----

This conflicts with #357 and still uses "all" in lower case, but I wanted to keep these two concerns separately.