### PR TITLE
move ADDITIONAL_FILES from Source to Port level

### DIFF
--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -623,6 +623,18 @@ class Port(object):
 			if source.referencesFiles(files):
 				return True
 
+		if self.additionalFiles:
+			for additionalFile in self.additionalFiles:
+				if os.path.isdir(additionalFile):
+					# ensure there is a path separator at the end
+					additionalFile = os.path.join(additionalFile, '')
+					for fileName in files:
+						if os.path.commonprefix([additionalFile, fileName]) \
+								== additionalFile:
+							return True
+				elif additionalFile in files:
+					return True
+
 		if 'LICENSE' in self.recipeKeys:
 			for license in self.recipeKeys['LICENSE']:
 				if os.path.join(self.licensesDir, license) in files:
@@ -705,8 +717,21 @@ class Port(object):
 		"""Populates the work dir with referenced additional files"""
 
 		self.parseRecipeFileIfNeeded()
-		for source in self.sources:
-			source.populateAdditionalFiles(self.workDir)
+		if not self.additionalFiles:
+			return
+
+		additionalFilesDir = os.path.join(self.workDir, 'additional-files')
+
+		if not os.path.exists(additionalFilesDir):
+			os.mkdir(additionalFilesDir)
+
+		for additionalFile in self.additionalFiles:
+			if os.path.isdir(additionalFile):
+				shutil.copytree(additionalFile,
+					os.path.join(additionalFilesDir,
+						os.path.basename(additionalFile)))
+			else:
+				shutil.copy(additionalFile, additionalFilesDir)
 
 	def extractPatchset(self):
 		"""Extract patchsets from all sources"""
@@ -1002,11 +1027,18 @@ class Port(object):
 							keys['SOURCE_FILENAME'].get(index, None),
 							keys['CHECKSUM_SHA256'].get(index, None),
 							keys['SOURCE_DIR'].get(index, None),
-							keys['PATCHES'].get(index, []),
-							keys['ADDITIONAL_FILES'].get(index, []))
+							keys['PATCHES'].get(index, []))
 			if source.isFromSourcePackage:
 				basedOnSourcePackage = True
 			self.sources.append(source)
+
+		# ADDITIONAL_FILES refers to the files relative to the additional-files
+		# directory, make those absolute paths.
+		if 'ADDITIONAL_FILES' in keys:
+			self.additionalFiles = [
+				self.additionalFilesDir + '/' + additionalFile
+				for additionalFile in keys['ADDITIONAL_FILES']
+			]
 
 		# create packages
 		self.allPackages = []
@@ -1405,6 +1437,10 @@ class Port(object):
 		self.packagingBaseDir = self.packagingBaseDir[pathLengthToCut:]
 		self.packageInfoDir = self.packageInfoDir[pathLengthToCut:]
 		self.hpkgDir = self.hpkgDir[pathLengthToCut:]
+		self.additionalFiles = [
+			additionalFile[pathLengthToCut:]
+			for additionalFile in self.additionalFiles
+		]
 		self.workDir = ''
 
 		if not self.isMetaPort:

--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -1421,10 +1421,6 @@ class Port(object):
 		for package in self.allPackages:
 			package.adjustToChroot()
 
-		# unset directories which can't be reached from inside the chroot
-		self.baseDir = None
-		self.downloadDir = None
-
 		# the recipe file has a fixed same name in the chroot
 		self.preparedRecipeFile = '/port.recipe'
 		self.recipeFilePath = '/port.recipe'
@@ -1437,11 +1433,16 @@ class Port(object):
 		self.packagingBaseDir = self.packagingBaseDir[pathLengthToCut:]
 		self.packageInfoDir = self.packageInfoDir[pathLengthToCut:]
 		self.hpkgDir = self.hpkgDir[pathLengthToCut:]
+		self.workDir = ''
+		pathLengthToCut = len(self.baseDir)
 		self.additionalFiles = [
 			additionalFile[pathLengthToCut:]
 			for additionalFile in self.additionalFiles
 		]
-		self.workDir = ''
+
+		# unset directories which can't be reached from inside the chroot
+		self.baseDir = None
+		self.downloadDir = None
 
 		if not self.isMetaPort:
 			self.patchesDir = '/patches'

--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -1442,10 +1442,6 @@ class Port(object):
 		for package in self.allPackages:
 			package.adjustToChroot()
 
-		# unset directories which can't be reached from inside the chroot
-		self.baseDir = None
-		self.downloadDir = None
-
 		# the recipe file has a fixed same name in the chroot
 		self.preparedRecipeFile = '/port.recipe'
 		self.recipeFilePath = '/port.recipe'
@@ -1459,11 +1455,16 @@ class Port(object):
 		self.packageInfoDir = self.packageInfoDir[pathLengthToCut:]
 		self.hpkgDir = self.hpkgDir[pathLengthToCut:]
 		self.dummyPrefixDir = self.dummyPrefixDir[pathLengthToCut:]
+		self.workDir = ''
+		pathLengthToCut = len(self.baseDir)
 		self.additionalFiles = [
 			additionalFile[pathLengthToCut:]
 			for additionalFile in self.additionalFiles
 		]
-		self.workDir = ''
+
+		# unset directories which can't be reached from inside the chroot
+		self.baseDir = None
+		self.downloadDir = None
 
 		if not self.isMetaPort:
 			self.patchesDir = '/patches'

--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -628,6 +628,18 @@ class Port(object):
 			if source.referencesFiles(files):
 				return True
 
+		if self.additionalFiles:
+			for additionalFile in self.additionalFiles:
+				if os.path.isdir(additionalFile):
+					# ensure there is a path separator at the end
+					additionalFile = os.path.join(additionalFile, '')
+					for fileName in files:
+						if os.path.commonprefix([additionalFile, fileName]) \
+								== additionalFile:
+							return True
+				elif additionalFile in files:
+					return True
+
 		if 'LICENSE' in self.recipeKeys:
 			for license in self.recipeKeys['LICENSE']:
 				if os.path.join(self.licensesDir, license) in files:
@@ -710,8 +722,21 @@ class Port(object):
 		"""Populates the work dir with referenced additional files"""
 
 		self.parseRecipeFileIfNeeded()
-		for source in self.sources:
-			source.populateAdditionalFiles(self.workDir)
+		if not self.additionalFiles:
+			return
+
+		additionalFilesDir = os.path.join(self.workDir, 'additional-files')
+
+		if not os.path.exists(additionalFilesDir):
+			os.mkdir(additionalFilesDir)
+
+		for additionalFile in self.additionalFiles:
+			if os.path.isdir(additionalFile):
+				shutil.copytree(additionalFile,
+					os.path.join(additionalFilesDir,
+						os.path.basename(additionalFile)))
+			else:
+				shutil.copy(additionalFile, additionalFilesDir)
 
 	def extractPatchset(self):
 		"""Extract patchsets from all sources"""
@@ -1009,11 +1034,18 @@ class Port(object):
 							keys['SOURCE_FILENAME'].get(index, None),
 							keys['CHECKSUM_SHA256'].get(index, None),
 							keys['SOURCE_DIR'].get(index, None),
-							keys['PATCHES'].get(index, []),
-							keys['ADDITIONAL_FILES'].get(index, []))
+							keys['PATCHES'].get(index, []))
 			if source.isFromSourcePackage:
 				basedOnSourcePackage = True
 			self.sources.append(source)
+
+		# ADDITIONAL_FILES refers to the files relative to the additional-files
+		# directory, make those absolute paths.
+		if 'ADDITIONAL_FILES' in keys:
+			self.additionalFiles = [
+				self.additionalFilesDir + '/' + additionalFile
+				for additionalFile in keys['ADDITIONAL_FILES']
+			]
 
 		# create packages
 		self.allPackages = []
@@ -1427,6 +1459,10 @@ class Port(object):
 		self.packageInfoDir = self.packageInfoDir[pathLengthToCut:]
 		self.hpkgDir = self.hpkgDir[pathLengthToCut:]
 		self.dummyPrefixDir = self.dummyPrefixDir[pathLengthToCut:]
+		self.additionalFiles = [
+			additionalFile[pathLengthToCut:]
+			for additionalFile in self.additionalFiles
+		]
 		self.workDir = ''
 
 		if not self.isMetaPort:

--- a/HaikuPorter/RecipeAttributes.py
+++ b/HaikuPorter/RecipeAttributes.py
@@ -26,6 +26,13 @@ def getRecipeFormatVersion():
 
 recipeAttributes = {
 	# non-extendable and non-indexable, i.e. per-port attributes
+	'ADDITIONAL_FILES': {
+		'type': list,
+		'required': False,
+		'default': {},
+		'extendable': Extendable.NO,
+		'indexable': False,
+	},
 	'BUILD_PACKAGE_ACTIVATION_PHASE': {
 		'type': Phase,
 		'required': False,
@@ -84,13 +91,6 @@ recipeAttributes = {
 	},
 
 	# indexable, i.e. per-source attributes
-	'ADDITIONAL_FILES': {
-		'type': list,
-		'required': False,
-		'default': {},
-		'extendable': Extendable.NO,
-		'indexable': True,
-	},
 	'CHECKSUM_SHA256': {
 		'type': bytes,
 		'required': False,

--- a/HaikuPorter/Source.py
+++ b/HaikuPorter/Source.py
@@ -27,13 +27,12 @@ from .Utils import (ensureCommandIsAvailable, info, readStringFromFile,
 
 class Source(object):
 	def __init__(self, port, index, uris, fetchTargetName, checksum,
-				 sourceDir, patches, additionalFiles):
+				 sourceDir, patches):
 		self.index = index
 		self.uris = uris
 		self.fetchTargetName = fetchTargetName
 		self.checksum = checksum
 		self.patches = patches
-		self.additionalFiles = additionalFiles
 
 		## REFACTOR use property setters to handle branching based on instance
 		## variables
@@ -63,14 +62,6 @@ class Source(object):
 			self.patches = [
 				port.patchesDir + '/'
 				+ patch for patch in self.patches if not patch.strip(' \t').startswith('#')
-			]
-
-		# ADDITIONAL_FILES refers to the files relative to the additional-files
-		# directory, make those absolute paths.
-		if self.additionalFiles:
-			self.additionalFiles = [
-				port.additionalFilesDir + '/' + additionalFile
-				for additionalFile in self.additionalFiles
 			]
 
 		# determine filename of first URI
@@ -224,25 +215,6 @@ class Source(object):
 
 		port.setFlag('unpack', self.index)
 
-	def populateAdditionalFiles(self, baseDir):
-		if not self.additionalFiles:
-			return
-
-		additionalFilesDir = os.path.join(baseDir, 'additional-files')
-		if self.index != '1':
-			additionalFilesDir += '-' + self.index
-
-		if not os.path.exists(additionalFilesDir):
-			os.mkdir(additionalFilesDir)
-
-		for additionalFile in self.additionalFiles:
-			if os.path.isdir(additionalFile):
-				shutil.copytree(additionalFile,
-					os.path.join(additionalFilesDir,
-						os.path.basename(additionalFile)))
-			else:
-				shutil.copy(additionalFile, additionalFilesDir)
-
 	def validateChecksum(self, port):
 		"""Make sure that the SHA256-checksum matches the expectations"""
 
@@ -294,18 +266,6 @@ class Source(object):
 		if self.patches:
 			for patch in self.patches:
 				if patch in files:
-					return True
-
-		if self.additionalFiles:
-			for additionalFile in self.additionalFiles:
-				if os.path.isdir(additionalFile):
-					# ensure there is a path separator at the end
-					additionalFile = os.path.join(additionalFile, '')
-					for fileName in files:
-						if os.path.commonprefix([additionalFile, fileName]) \
-								== additionalFile:
-							return True
-				elif additionalFile in files:
 					return True
 
 		return False
@@ -491,10 +451,6 @@ class Source(object):
 		pathLengthToCut = len(port.workDir)
 		self.sourceBaseDir = self.sourceBaseDir[pathLengthToCut:]
 		self.sourceDir = self.sourceDir[pathLengthToCut:]
-		self.additionalFiles = [
-			additionalFile[pathLengthToCut:]
-			for additionalFile in self.additionalFiles
-		]
 
 	def _initImplicitGitRepo(self):
 		"""Import sources into git repository"""


### PR DESCRIPTION
It doesn't really make sense to have additional files per source and separate "additional-files-2" etc. directories. So handle these completely globally per port instead.

Part of #363.