### PR TITLE
add CREATE_SOURCE_PACKAGES to haikuports-sample.conf

### DIFF
--- a/haikuports-sample.conf
+++ b/haikuports-sample.conf
@@ -18,7 +18,7 @@
 #	function inrecipe { find /path/to/your/haikuports -maxdepth 3 \
 #            -name "*.recipe" | xargs grep -ni --col $1; }
 #
-#	alias hp="haikuporter -S -j8 --no-source-packages --get-dependencies"
+#	alias hp="haikuporter -S -j8 --get-dependencies"
 
 # ==================
 # Required settings:
@@ -71,3 +71,8 @@ PACKAGER="My Name <mymail@mydomain.org>"
 #     Example is x86 (gcc4) packages on a x86_gcc2 (gcc2) system
 #     Default is no secondary target architectures.
 #SECONDARY_TARGET_ARCHITECTURES="x86"
+
+# --------------
+# CREATE_SOURCE_PACKAGES
+#     Enable the creation of source packages. By default, they are disabled.
+#CREATE_SOURCE_PACKAGES="yes"


### PR DESCRIPTION
This is disabled by default since the configuration setting exists. Adding it to the sample config file should make it more discoverable how to enable them if needed.

Remove the command line option from the recommended alias, as it isn't needed because it is disabled by default.