### PR TITLE
Introduce a dependency info marker file at Port level

### DIFF
--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -109,7 +109,7 @@ class Port(object):
 		self.recipeFilePath = self.baseDir + '/' + self.baseName + '-' \
 			+ self.version + '.recipe'
 
-		self.dependencyInfoName = self.versionedName + '.DependencyInfo'
+		self.dependencyInfoMarkerName = self.versionedName + '.DependencyInfoMarker'
 
 		self.revision = None
 		self.fullVersion = None
@@ -510,11 +510,18 @@ class Port(object):
 		for package in self.packages:
 			package.writeDependencyInfoIntoRepository(self._repositoryDir)
 
+		dependencyInfoMarkerFile = os.path.join(self._repositoryDir, self.dependencyInfoMarkerName)
+		touchFile(dependencyInfoMarkerFile)
+
 	def removeDependencyInfosFromRepository(self):
 		"""Remove all DependencyInfo-files for this port from the repository"""
 		self.parseRecipeFileIfNeeded()
 		for package in self.packages:
 			package.removeDependencyInfoFromRepository(self._repositoryDir)
+
+		dependencyInfoMarkerFile = os.path.join(self._repositoryDir, self.dependencyInfoMarkerName)
+		if os.path.exists(dependencyInfoMarkerFile):
+			os.remove(dependencyInfoMarkerFile)
 
 	@property
 	def mainPackage(self):

--- a/HaikuPorter/Repository.py
+++ b/HaikuPorter/Repository.py
@@ -438,12 +438,12 @@ class Repository(object):
 					continue
 
 				# update all dependency-infos of port if the recipe is newer
-				# than the main dependency-info of that port
-				mainDependencyInfoFile = os.path.join(self.path,
-					port.dependencyInfoName)
-				if (os.path.exists(mainDependencyInfoFile)
+				# than the dependency-info marker of that port
+				dependencyInfoMarkerFile = os.path.join(self.path,
+					port.dependencyInfoMarkerName)
+				if (os.path.exists(dependencyInfoMarkerFile)
 					and (os.path.getmtime(port.recipeFilePath)
-						<= os.path.getmtime(mainDependencyInfoFile))):
+						<= os.path.getmtime(dependencyInfoMarkerFile))):
 					activePorts.append(portID)
 					break
 
@@ -479,7 +479,7 @@ class Repository(object):
 				except SystemExit as e:
 					# take notice of broken recipe file
 					touchFile(skippedFlag)
-					if not os.path.exists(mainDependencyInfoFile):
+					if not os.path.exists(dependencyInfoMarkerFile):
 						if not self.quiet:
 							print('\trecipe for %s is still broken:' % portID)
 							print(prefixLines('\t', e.code))
@@ -526,6 +526,17 @@ class Repository(object):
 				if not getOption('noPackageObsoletion'):
 					# obsolete corresponding package, if any
 					self._removePackagesForDependencyInfo(dependencyInfo)
+
+		dependencyInfoMarkers = glob.glob(self.path + '/*.DependencyInfoMarker')
+		for dependencyInfoMarker in dependencyInfoMarkers:
+			dependencyInfoMarkerFileName = os.path.basename(dependencyInfoMarker)
+			portID \
+				= dependencyInfoMarkerFileName[:dependencyInfoMarkerFileName.rindex('.')]
+
+			if not portID or portID not in activePorts:
+				if not self.quiet:
+					print('\tremoving ' + dependencyInfoMarkerFileName)
+				os.remove(dependencyInfoMarker)
 
 	def _removeStaleCachedRecipes(self, activePorts):
 		"""check for any cached recipe that no longer have a corresponding


### PR DESCRIPTION
... and use it to determine whether the dependency infos of a Port are outdated instead of the dependency info file of the main package, which may not exist if there is no main package. We can't use the dependency info file of another package because we don't know its name and would need to parse the recipe for that. The marker file is empty and is only used for its timestamp.

Fixes #380.

Note: After this change, haikuporter will update all dependency infos once because it thinks that all are outdated.