### PR TITLE
Fix errors for tar files when extracting

### DIFF
--- a/HaikuPorter/Utils.py
+++ b/HaikuPorter/Utils.py
@@ -131,7 +131,7 @@ def unpackArchive(archiveFile, targetBaseDir, subdir):
 			tarFile = tarfile.open(archiveFile, 'r', tarinfo=MyTarInfo)
 
 		if subdir is None:
-			tarFile.extractall(path=targetBaseDir)
+			tarFile.extractall(path=targetBaseDir, filter='tar')
 		else:
 			def filterByDir(members):
 				for member in members:
@@ -144,7 +144,7 @@ def unpackArchive(archiveFile, targetBaseDir, subdir):
 							member.gid = 0
 							member.uid = 0
 						yield member
-			tarFile.extractall(members=filterByDir(tarFile), path=targetBaseDir)
+			tarFile.extractall(members=filterByDir(tarFile), path=targetBaseDir, filter='tar')
 
 		tarFile.close()
 	elif zipfile.is_zipfile(archiveFile):


### PR DESCRIPTION
appstream for one: 'appstream-1.1.3/tests/samples/compose/usr/share/metainfo/org.example.nonexistent-badlink.metainfo.xml' is a link to an absolute path