### PR TITLE
switch build to setuptools, introduce setuptools-scm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.pyc
 *.pyo
 recipeCache/
+build/
 dist/
+*.egg-info/

--- a/HaikuPorter/Options.py
+++ b/HaikuPorter/Options.py
@@ -13,10 +13,10 @@
 
 # -- Modules ------------------------------------------------------------------
 
+from importlib.metadata import version, PackageNotFoundError
 from multiprocessing import cpu_count
 from optparse import OptionGroup, OptionParser
 
-from .__version__ import __version__
 from .Utils import isCommandAvailable, warn
 
 # -- global options -----------------------------------------------------------
@@ -42,6 +42,11 @@ def setCommaSeparatedList(option, opt, value, parser):
 
 def parseOptions():
 	"""Does command line argument parsing"""
+
+	try:
+		__version__ = version("HaikuPorter")
+	except PackageNotFoundError:
+		__version__ = '(not installed)'
 
 	parser = OptionParser(
 						usage='usage: %prog [options] portname[-portversion]',

--- a/HaikuPorter/__init__.py
+++ b/HaikuPorter/__init__.py
@@ -2,5 +2,3 @@
 #
 # Copyright 2013 Oliver Tappe
 # Distributed under the terms of the MIT License.
-
-from .__version__ import *

--- a/HaikuPorter/__version__.py
+++ b/HaikuPorter/__version__.py
@@ -1,6 +1,0 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright 2013 Oliver Tappe
-# Distributed under the terms of the MIT License.
-
-__version__ = '1.5.1'

--- a/buildmaster/backend/Dockerfile
+++ b/buildmaster/backend/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
 	&& apt-get -y install attr autoconf automake bison coreutils curl flex \
 		gawk gcc g++ git libcurl4-openssl-dev make nasm \
 		python3 python3-isort python3-boto3 python3-pymongo python3-paramiko \
+		python3-setuptools-scm python3-pip \
 		tar texinfo vim wget zlib1g-dev; \
 	if [ "$(uname -m)" = "x86_64" ]; then apt install -y gcc-multilib; fi; \
 	apt-get clean
@@ -33,10 +34,8 @@ ADD . /tmp/haikuporter
 COPY --from=host-tools /tmp/haiku/generated/objects/linux/*/release/tools/package/package /usr/local/bin/
 COPY --from=host-tools /tmp/haiku/generated/objects/linux/*/release/tools/package_repo/package_repo /usr/local/bin/
 
-RUN PYVERSION=$(python3 -V | awk '{ print $2 }') \
-	&& mkdir -p /usr/local/lib/python${PYVERSION%.*}/dist-packages \
-	&& mv /tmp/haikuporter/HaikuPorter /usr/local/lib/python${PYVERSION%.*}/dist-packages/ \
-	&& mv /tmp/haikuporter/haikuporter.py /usr/local/bin/haikuporter \
+RUN --mount=source=.git,target=/tmp/haikuporter/.git,type=bind,rw \
+	python3 -m pip install /tmp/haikuporter[buildmaster] --break-system-packages \
 	&& cp /tmp/haikuporter/buildmaster/backend/assets/bin/* /usr/local/bin/ \
 	&& cp /tmp/haikuporter/buildmaster/backend/assets/bootstrap /bin/ \
 	&& cp /tmp/haikuporter/buildmaster/backend/assets/loop /bin/ \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = [ "flit_core >= 3.9.0, <4" ]
-build-backend = "flit_core.buildapi"
+requires = [ "setuptools>=80", "setuptools-scm[simple]>=9.2" ]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "HaikuPorter"
@@ -16,3 +16,6 @@ buildmaster = [ "boto3", "paramiko", "pymongo" ]
 
 [project.scripts]
 haikuporter = "HaikuPorter.__main__:main"
+
+[tool.setuptools.packages.find]
+include = [ "HaikuPorter*" ]


### PR DESCRIPTION
This gets rid of specifying the version number manually in `__version__.py` and instead reads it from git tags.

flit-core doesn't support this natively, thus we switch to setuptools for the build (which is required by setuptools-scm anyway).

Switch the buildmaster docker build back to using pip.