### PR TITLE
buildmaster: set haikuporter version in the container from git tag

### DIFF
--- a/.github/workflows/buildmaster.yml
+++ b/.github/workflows/buildmaster.yml
@@ -34,6 +34,8 @@ jobs:
       with:
         context: .
         file: buildmaster/backend/Dockerfile
+        build-args: |
+          haikuporter_version=${{ steps.detect-version.outputs.RELEASE_VERSION }}
         push: true
         tags: |
           ${{env.REPOSITORY}}/buildmaster:${{ steps.detect-version.outputs.RELEASE_VERSION }}-amd64

--- a/buildmaster/backend/Dockerfile
+++ b/buildmaster/backend/Dockerfile
@@ -33,7 +33,10 @@ ADD . /tmp/haikuporter
 COPY --from=host-tools /tmp/haiku/generated/objects/linux/*/release/tools/package/package /usr/local/bin/
 COPY --from=host-tools /tmp/haiku/generated/objects/linux/*/release/tools/package_repo/package_repo /usr/local/bin/
 
+ARG haikuporter_version=0.0.0
+
 RUN PYVERSION=$(python3 -V | awk '{ print $2 }') \
+	&& echo "__version__ = '${haikuporter_version}'" > /tmp/haikuporter/HaikuPorter/__version__.py \
 	&& mkdir -p /usr/local/lib/python${PYVERSION%.*}/dist-packages \
 	&& mv /tmp/haikuporter/HaikuPorter /usr/local/lib/python${PYVERSION%.*}/dist-packages/ \
 	&& mv /tmp/haikuporter/haikuporter.py /usr/local/bin/haikuporter \

--- a/buildmaster/backend/Makefile
+++ b/buildmaster/backend/Makefile
@@ -4,7 +4,7 @@
 REPO=ghcr.io/haikuports
 VERSION=$(shell git describe --dirty --tags --abbrev=1)
 default:
-	podman build --no-cache --tag ${REPO}/haikuporter/buildmaster:${VERSION} -f Dockerfile ../..
+	podman build --no-cache --tag ${REPO}/haikuporter/buildmaster:${VERSION} -f Dockerfile --build-arg haikuporter_version=${VERSION} ../..
 push:
 	podman push ${REPO}/haikuporter/buildmaster:${VERSION}
 enter:


### PR DESCRIPTION
This way, it can't diverge any more from the tag.

----

This is a more lightweight alternative to #394, which actually does work.

The haikuports recipe for haikuporter can do something similar (`echo "__version__ = '$portVersion'" > HaikuPorter/__version__.py`) to handle this.