### PR TITLE
Skip copying fonts settings when nonexistent

### DIFF
--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -922,8 +922,8 @@ if ! [ -e boot/system/settings/etc/profile ]; then
 	echo 'export PS1="\w> "' >boot/system/settings/etc/profile
 	chmod +x boot/system/settings/etc/profile
 fi
-# copy font settings
-if ! [ -e boot/system/settings/fonts ]; then
+# copy font settings, if any
+if [ -d /system/settings/fonts ] && ! [ -e boot/system/settings/fonts ]; then
 	cp -r /system/settings/fonts boot/system/settings/
 fi
 


### PR DESCRIPTION
They exist normally, but not on the bootstrap image.