### PR TITLE
optionally enable the network again

### DIFF
--- a/HaikuPorter/ConfigParser.py
+++ b/HaikuPorter/ConfigParser.py
@@ -8,7 +8,7 @@
 import functools
 from subprocess import CalledProcessError, check_output
 
-from .RecipeTypes import (Architectures, Extendable, LinesOfText,
+from .RecipeTypes import (AllowNetworkMode, Architectures, Extendable, LinesOfText,
                           MachineArchitecture, Phase, ProvidesList,
                           RequiresList, Status, YesNo)
 from .ShellScriptlets import configFileEvaluatorScript, getShellVariableSetters
@@ -210,6 +210,12 @@ class ConfigParser(object):
 					sysExit("Value for %s should be 'yes' or 'no' in %s"
 							% (key, filename))
 				entries[key] = YesNo.toBool(valueString)
+			elif attrType == AllowNetworkMode:
+				valueString = valueString.lower()
+				if valueString not in AllowNetworkMode.getAllowedValues():
+					sysExit("Value for %s should be 'yes', 'no' or 'test_only' in %s"
+							% (key, filename))
+				entries[key] = AllowNetworkMode.parse(valueString)
 			else:
 				sysExit('type of key %s in file %s is unsupported'
 						% (key, filename))

--- a/HaikuPorter/Configuration.py
+++ b/HaikuPorter/Configuration.py
@@ -11,7 +11,7 @@ import re
 
 from .ConfigParser import ConfigParser
 from .Options import getOption
-from .RecipeTypes import Extendable, MachineArchitecture, YesNo
+from .RecipeTypes import AllowNetworkMode, Extendable, MachineArchitecture, YesNo
 from .Utils import sysExit, warn
 
 
@@ -36,6 +36,14 @@ def which(program):
 
 # allowed types of the configuration file values
 haikuportsAttributes = {
+	'ALLOW_NETWORK_IN_CHROOT': {
+		'type': AllowNetworkMode,
+		'required': False,
+		'default': AllowNetworkMode.NO,
+		'extendable': Extendable.NO,
+		'indexable': False,
+		'setAttribute': 'allowNetworkInChroot',
+	},
 	'ALLOW_UNTESTED': {
 		'type': YesNo,
 		'required': False,
@@ -262,6 +270,7 @@ class Configuration(object):
 		self.packager = None
 		self.packagerName = None
 		self.packagerEmail = None
+		self.allowNetworkInChroot = AllowNetworkMode.NO
 		self.allowUntested = False
 		self.allowUnsafeSources = False
 		self.createSourcePackages = True
@@ -323,6 +332,10 @@ class Configuration(object):
 	@staticmethod
 	def getPackagerEmail():
 		return Configuration.configuration.packagerEmail
+
+	@staticmethod
+	def shallAllowNetworkInChroot():
+		return Configuration.configuration.allowNetworkInChroot
 
 	@staticmethod
 	def shallAllowUntested():

--- a/HaikuPorter/Port.py
+++ b/HaikuPorter/Port.py
@@ -29,7 +29,8 @@ from .Configuration import Configuration
 from .Options import getOption
 from .Package import PackageType, packageFactory, sourcePackageFactory
 from .RecipeAttributes import getRecipeAttributes
-from .RecipeTypes import Architectures, Extendable, MachineArchitecture, Phase, Status
+from .RecipeTypes import (AllowNetworkMode, Architectures, Extendable,
+                          MachineArchitecture, Phase, Status)
 from .ReleaseChecker import createReleaseChecker
 from .RequiresUpdater import RequiresUpdater
 from .ShellScriptlets import (cleanupChrootScript, getShellVariableSetters,
@@ -820,6 +821,9 @@ class Port(object):
 				'recipeFile': self.preparedRecipeFile,
 				'targetArchitecture': self.targetArchitecture,
 				'portDir': self.baseDir,
+				'networkEnabled': ('true'
+					if Configuration.shallAllowNetworkInChroot() == AllowNetworkMode.YES
+					else 'false'),
 			}
 			if Configuration.isCrossBuildRepository():
 				chrootEnvVars['crossSysrootDir'] \
@@ -930,6 +934,9 @@ class Port(object):
 			'recipeFile': self.preparedRecipeFile,
 			'targetArchitecture': self.targetArchitecture,
 			'portDir': self.baseDir,
+			'networkEnabled': ('true'
+				if Configuration.shallAllowNetworkInChroot() != AllowNetworkMode.NO
+				else 'false'),
 		}
 
 		def makeChrootFunctions():

--- a/HaikuPorter/RecipeTypes.py
+++ b/HaikuPorter/RecipeTypes.py
@@ -173,3 +173,27 @@ class Extendable(str):
 	INHERITED = 'inherited',
 	DEFAULT = 'default'
 
+# -- AllowNetworkMode ---------------------------------------------------------
+
+# Defines the possible modes whether to allow the network in the build chroot:
+#	NO		   -> Accessing the network is not allowed.
+#	YES		   -> Accessing the network is allowed.
+#	TEST_ONLY  -> Accessing the network is only allowed during TEST, but not in
+#				  BUILD or INSTALL.
+
+class AllowNetworkMode(str):
+	NO = 'no'
+	YES = 'yes'
+	TEST_ONLY = 'test_only'
+
+	@staticmethod
+	def getAllowedValues():
+		return ['yes', 'no', 'true', 'false', 'test_only']
+
+	@staticmethod
+	def parse(value):
+		if value.lower() == 'yes' or value.lower() == 'true':
+			return AllowNetworkMode.YES
+		if value.lower() == 'test_only':
+			return AllowNetworkMode.TEST_ONLY
+		return AllowNetworkMode.NO

--- a/HaikuPorter/ShellScriptlets.py
+++ b/HaikuPorter/ShellScriptlets.py
@@ -889,7 +889,8 @@ fi
 # Shell scriptlet that prepares a chroot environment for entering.
 # Invoked with $packages filled with the list of packages that should
 # be activated (via system/packages) and $recipeFilePath pointing to the
-# recipe file.
+# recipe file. $networkEnabled will be true or false to determine whether
+# to copy the network settings or not.
 # Additionally, $crossSysrootDir will be set to the cross-sysroot directory
 # when the cross-build repository is active and $targetArchitecture will be
 # filled with the target architecture.
@@ -921,6 +922,10 @@ fi
 if ! [ -e boot/system/settings/etc/profile ]; then
 	echo 'export PS1="\w> "' >boot/system/settings/etc/profile
 	chmod +x boot/system/settings/etc/profile
+fi
+# copy network settings, if allowed
+if $networkEnabled && ! [ -e boot/system/settings/network ]; then
+	cp -r /system/settings/network boot/system/settings/
 fi
 # copy font settings, if any
 if [ -d /system/settings/fonts ] && ! [ -e boot/system/settings/fonts ]; then


### PR DESCRIPTION
This adds a new configuration setting ALLOW_NETWORK_IN_CHROOT to enable copying the network settings into the chroot again, either in general or for tests only. The network is still disabled by default.